### PR TITLE
Stage 8: Deployable Companion v0

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Instead of relying only on filenames and exact keywords, it adds a semantic laye
 - 🧠 **Rediscover related notes** from the document you are already working on.
 - 🧹 **Review potential semantic duplicates** and overlapping ideas.
 - 💬 **Ask your Vault** and receive a streamed, source-backed answer from indexed notes.
+- 🛰️ **Mirror semantic state to an optional Companion** running locally or behind HTTPS on your own VPS.
 - 🗺️ **Audit your vault** for clusters, orphan notes, tags, folders, and structural issues.
 - ✍️ **Use AI inside Obsidian** for writing, transformations, flashcards, Dataview, and batch processing.
 - 🔒 **Choose local-first options** with Ollama, or connect remote AI providers when you want them.
@@ -198,7 +199,7 @@ Vault Audit AI separates local storage from provider-side processing so you can 
   .obsidian/plugins/ai-knowledge-hub/semantic-index/
   ```
 
-- The plugin does not upload stored vectors or their index metadata.
+- Stored vectors and index metadata remain local unless the optional Companion integration is explicitly enabled and synchronized.
 - When OpenRouter or another remote embedding API is selected, note chunks are sent to that endpoint during indexing and synchronization.
 - Semantic search queries are sent to the selected embedding provider for query embedding.
 - **Ask your Vault** performs one query embedding for retrieval. When the embedding provider is remote, the question is sent to that provider; retrieved source chunks are not re-embedded during Ask.
@@ -206,6 +207,10 @@ Vault Audit AI separates local storage from provider-side processing so you can 
 - **Find similar notes** and potential duplicate detection operate on vectors already present in the local index and do not make an embedding-provider request for the comparison itself.
 - Ollama allows embedding generation to remain local when connected to a local Ollama instance.
 - Automatic semantic synchronization never edits Markdown files. It reads the latest Markdown content and changes only the local vector index.
+- Companion is disabled by default. Entering an endpoint alone does not upload Vault data.
+- When Companion sync is enabled, the configured endpoint receives a stable random Vault ID, vault-relative paths, current Markdown, full chunk text, chunk/source metadata, embeddings, and semantic descriptor metadata. Localhost keeps that mirror on the same machine; a remote endpoint transmits and persists it on that server.
+- Remote Companion endpoints must use HTTPS. The Companion bearer token is independent of embedding and language-model credentials; provider API keys are never sent to Companion.
+- Companion has no telemetry, MCP, agents, note editing, or Vault write-back.
 - Writing, batch, and audit operations send the content required for the requested action to the configured language-model provider.
 - Clipboard insertion writes generated output to the system clipboard.
 
@@ -277,6 +282,8 @@ Chunk search + document representations
 
 Stable chunk hashes drive incremental deltas so unchanged chunks are reused.
 
+An optional standalone [Companion service](companion/README.md) receives versioned JSON over HTTP(S) after local semantic commits. Snapshot capture reuses the committed vectors and releases the semantic barrier before network I/O. Deterministic manifest reconciliation avoids retransmitting unchanged Markdown or embeddings and repairs events missed while either process was offline.
+
 A debounced event coordinator coalesces Markdown path changes, while startup reconciliation catches offline changes. Manual and automatic indexing share one mutation queue. Rename batches reach the vector store as one durable mutation.
 
 The vector store uses guarded temporary-file replacement, backup-aware recovery, and one shared store per semantic index path in the plugin runtime. Document discovery reads a defensive committed snapshot from that same store.
@@ -289,6 +296,8 @@ Clear and rebuild are explicit operations and do not modify source notes.
 - Ask your Vault is a one-shot question flow; it does not keep a multi-turn conversation history.
 - Automatic synchronization covers Markdown notes only; attachments, Canvas files, images, and other file types are ignored.
 - The vector store does not use an ANN or HNSW index.
+- Companion v0 is a self-hosted read-only mirror. It provides no retrieval API for end users, MCP, dashboard, accounts, TLS termination, or write-back; read-only MCP is deferred to a later stage.
+- Companion requires Node.js 24 or newer and uses Node's built-in SQLite API, which Node 24 currently labels experimental.
 - Similarity search performs a local linear scan and is intended for small and medium personal vaults.
 - Similar Notes represents a document as the normalized mean of its chunk vectors; broad or multi-topic notes may therefore receive less intuitive rankings.
 - Potential duplicate detection compares exact document-vector pairs in quadratic time and is intended for small and medium personal vaults.

--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ Vault Audit AI separates local storage from provider-side processing so you can 
 - Companion is disabled by default. Entering an endpoint alone does not upload Vault data.
 - When Companion sync is enabled, the configured endpoint receives a stable random Vault ID, vault-relative paths, current Markdown, full chunk text, chunk/source metadata, embeddings, and semantic descriptor metadata. Localhost keeps that mirror on the same machine; a remote endpoint transmits and persists it on that server.
 - Remote Companion endpoints must use HTTPS. The Companion bearer token is independent of embedding and language-model credentials; provider API keys are never sent to Companion.
+- Changing Companion enablement, endpoint, token, timeout, or identity invalidates obsolete queued synchronization. An old plan cannot start later batches or retries, and disabling synchronization does not delete either the local semantic index or already mirrored Companion data.
 - Companion has no telemetry, MCP, agents, note editing, or Vault write-back.
 - Writing, batch, and audit operations send the content required for the requested action to the configured language-model provider.
 - Clipboard insertion writes generated output to the system clipboard.
@@ -298,6 +299,7 @@ Clear and rebuild are explicit operations and do not modify source notes.
 - The vector store does not use an ANN or HNSW index.
 - Companion v0 is a self-hosted read-only mirror. It provides no retrieval API for end users, MCP, dashboard, accounts, TLS termination, or write-back; read-only MCP is deferred to a later stage.
 - Companion requires Node.js 24 or newer and uses Node's built-in SQLite API, which Node 24 currently labels experimental.
+- Obsidian `requestUrl` cannot physically cancel a transport already handed off. Timeout, abort, disable, or configuration invalidation prevents subsequent queued requests, plan-to-batch transitions, batches, and retries, but the already-started HTTP transport may still finish.
 - Similarity search performs a local linear scan and is intended for small and medium personal vaults.
 - Similar Notes represents a document as the normalized mean of its chunk vectors; broad or multi-topic notes may therefore receive less intuitive rankings.
 - Potential duplicate detection compares exact document-vector pairs in quadratic time and is intended for small and medium personal vaults.

--- a/api.test.ts
+++ b/api.test.ts
@@ -49,6 +49,13 @@ function settings(overrides: Partial<AIHubSettings> = {}): AIHubSettings {
     },
     semanticAutoSyncSuspended: false,
     ...overrides,
+    companion: overrides.companion ?? {
+      enabled: false,
+      endpoint: "http://127.0.0.1:27124",
+      token: "",
+      timeoutMs: 5000,
+      vaultId: "11111111-1111-4111-8111-111111111111",
+    },
   };
 }
 

--- a/companion/.env.example
+++ b/companion/.env.example
@@ -1,0 +1,6 @@
+HOST=127.0.0.1
+PORT=27124
+COMPANION_TOKEN=replace-with-a-long-random-secret
+DATA_DIR=./data
+ALLOW_REMOTE_BIND=false
+LOG_LEVEL=info

--- a/companion/.gitignore
+++ b/companion/.gitignore
@@ -1,0 +1,7 @@
+dist/
+coverage/
+data/
+.env
+*.sqlite
+*.sqlite-shm
+*.sqlite-wal

--- a/companion/README.md
+++ b/companion/README.md
@@ -1,0 +1,204 @@
+# Vault Audit AI Companion
+
+Companion v0 is a standalone Node.js service that stores a persistent, read-only mirror of Vault Audit AI semantic state. The same source and build run locally and on a Linux VPS; only environment variables differ.
+
+Companion never opens an Obsidian Vault directory, never writes Markdown, has no shared-filesystem or shared-process assumption, and does not implement MCP or write-back.
+
+## Requirements
+
+- Node.js 24 LTS or newer
+- npm
+- A long random bearer token
+
+Node 24's built-in `node:sqlite` module is used so installation does not compile or download a native database addon. Node 24 currently labels this API experimental, so operators should stay on a supported Node 24 LTS patch release and review Node release notes before a major upgrade.
+
+## Local installation
+
+```sh
+git clone https://github.com/zinverno/obsidian-ai-hub.git
+cd obsidian-ai-hub/companion
+npm ci
+npm run build
+cp .env.example .env
+```
+
+Edit `.env`, replace the example token, then start:
+
+```sh
+npm test
+npm start
+```
+
+`npm start` uses Node's `--env-file-if-exists=.env`; ordinary process environment variables work without an `.env` file and take precedence according to Node's env-file behavior.
+
+Configure the plugin with `http://127.0.0.1:27124`, the same token, explicitly enable Companion, and select **Sync now**. Merely entering an endpoint does not upload data.
+
+## Companion-only sparse checkout
+
+Only `companion/` is needed on a server:
+
+```sh
+git clone --filter=blob:none --no-checkout \
+  https://github.com/zinverno/obsidian-ai-hub.git
+cd obsidian-ai-hub
+git sparse-checkout init --cone
+git sparse-checkout set companion
+git checkout main
+cd companion
+npm ci
+npm run typecheck
+npm test
+npm run build
+cp .env.example .env
+npm start
+```
+
+No root `npm install`, plugin build, Obsidian dependency, Vault directory, or source file outside `companion/` is required.
+
+## Linux VPS
+
+Use the same sparse-checkout, `npm ci`, tests, and build shown above. The recommended production topology keeps Companion on loopback and terminates TLS at a reverse proxy:
+
+```text
+Internet -> HTTPS -> Caddy/Nginx -> 127.0.0.1:27124 -> Companion -> SQLite
+```
+
+Example production environment:
+
+```sh
+HOST=127.0.0.1
+PORT=27124
+COMPANION_TOKEN=a-long-random-secret
+DATA_DIR=/var/lib/vault-audit-companion
+ALLOW_REMOTE_BIND=false
+LOG_LEVEL=info
+```
+
+Minimal Caddy configuration:
+
+```caddyfile
+vault.example.com {
+    reverse_proxy 127.0.0.1:27124
+}
+```
+
+DNS must point to the VPS, ports 80/443 must be allowed as required by the reverse proxy, and the operator is responsible for TLS and firewall configuration. Localhost HTTP is acceptable. Never send the bearer token or Vault mirror over plaintext Internet HTTP. Companion does not terminate TLS.
+
+Direct non-loopback binding is available only when both `HOST` is non-loopback and `ALLOW_REMOTE_BIND=true`; it is not the recommended reverse-proxy configuration.
+
+An optional systemd unit can run `npm start` with `WorkingDirectory` set to the checked-out `companion` directory and `EnvironmentFile` set to a protected environment file. systemd and Docker are not required.
+
+## Configuration
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `HOST` | `127.0.0.1` | Listen address. Non-loopback requires explicit opt-in. |
+| `PORT` | `27124` | TCP port, 1–65535. |
+| `COMPANION_TOKEN` | none | Required bearer secret; startup fails when empty. |
+| `DATA_DIR` | `./data` | Writable persistent SQLite directory. |
+| `ALLOW_REMOTE_BIND` | `false` | Must be `true` for a non-loopback `HOST`. |
+| `LOG_LEVEL` | `info` | `debug`, `info`, `warn`, or `error`. |
+
+Invalid configuration and inaccessible storage fail at startup with an actionable, redacted message. Tokens, authorization headers, provider keys, note bodies, and chunk text are not logged.
+
+## Protocol v1
+
+All authenticated requests send:
+
+```http
+Authorization: Bearer <COMPANION_TOKEN>
+X-Companion-Protocol-Version: 1
+Content-Type: application/json
+```
+
+An incompatible or missing protocol version receives HTTP 409 and `PROTOCOL_VERSION_MISMATCH`. Errors have one stable envelope and never include a stack trace or raw SQLite error:
+
+```json
+{"error":{"code":"INVALID_REQUEST","message":"..."}}
+```
+
+Routes:
+
+- `GET /health` — unauthenticated; returns only `{"status":"ok","protocolVersion":1}`.
+- `GET /v1/status` — authenticated aggregate server status.
+- `GET /v1/vaults/:vaultId/status` — authenticated aggregate state for one UUID.
+- `POST /v1/vaults/:vaultId/reconcile/plan` — compact manifest comparison.
+- `POST /v1/vaults/:vaultId/sync/batch` — transactional `UPSERT`, `DELETE`, and `RENAME` operations.
+
+Reconciliation request:
+
+```json
+{
+  "protocolVersion": 1,
+  "generation": 12,
+  "descriptor": {
+    "providerId": "openai-compatible",
+    "model": "text-embedding-3-small",
+    "baseUrl": "https://api.openai.com/v1",
+    "dimensions": 1536,
+    "embeddingSpaceId": "embedding-space:v1|...",
+    "normalized": true
+  },
+  "notes": [
+    {
+      "path": "Notes/A.md",
+      "contentHash": "...",
+      "chunks": [{"chunkId":"chunk-...","contentHash":"..."}]
+    }
+  ]
+}
+```
+
+Reconciliation response:
+
+```json
+{
+  "protocolVersion": 1,
+  "generation": 12,
+  "serverGeneration": 11,
+  "replaceVault": false,
+  "uploadPaths": ["Notes/A.md"],
+  "deletePaths": ["Removed.md"],
+  "unchangedPaths": []
+}
+```
+
+Batch request:
+
+```json
+{
+  "protocolVersion": 1,
+  "generation": 12,
+  "descriptor": {"providerId":"...","model":"...","baseUrl":"https://...","dimensions":3,"embeddingSpaceId":"...","normalized":true},
+  "replaceVault": false,
+  "operations": [
+    {"type":"DELETE","path":"Removed.md"},
+    {"type":"UPSERT","note":{"path":"A.md","content":"# A","contentHash":"...","metadata":{},"chunks":[]}},
+    {"type":"RENAME","oldPath":"Old.md","note":{"path":"New.md","content":"# New","contentHash":"...","metadata":{},"chunks":[]}}
+  ]
+}
+```
+
+Each real chunk also carries `chunkId`, `notePath`, `ordinal`, `headingPath`, full `text`, `contentHash`, the four-value source range, and the full numeric `embedding`. A successful response is:
+
+```json
+{"protocolVersion":1,"generation":12,"applied":true,"stale":false,"operationsApplied":3}
+```
+
+Requests are bounded to 16 MiB, 100 operations per batch, 4 MiB per note, and 10,000 chunks per note.
+
+## Reconciliation and vector-space rules
+
+The plugin sends a deterministic manifest first. Companion returns only missing/changed paths to upload and stale paths to delete; identical manifests do no work and resend no Markdown or embeddings. Incremental events use bounded transactional batches. Repeating a batch replaces the same `(vaultId, path)` and `(vaultId, chunkId)` records, so operations are idempotent.
+
+`generation` orders frozen local semantic snapshots. Older batches cannot overwrite newer stored generations. Every record is isolated by stable random `vaultId`, never by filesystem path.
+
+The descriptor preserves the plugin's provider, model, normalized endpoint, dimensions, canonical embedding-space fingerprint, and normalized-vector flag. Ordinary batches with a different descriptor receive `DESCRIPTOR_MISMATCH`. Explicit reconciliation plans `replaceVault=true`; the first replacement batch atomically clears the old vector space before inserting new records. Compatible and incompatible vectors are never mixed.
+
+The Vault remains authoritative. Companion's schema contains `vaults`, `notes`, and `chunks` tables with foreign keys and cascade deletion. SQLite WAL plus explicit `BEGIN IMMEDIATE` transactions make each batch atomic. Schema changes use ordered, idempotent `PRAGMA user_version` migrations.
+
+## Privacy and security
+
+When synchronization is enabled, the configured endpoint receives the stable random vault ID, vault-relative note paths, current Markdown, chunk text, chunk/source metadata, embeddings, and semantic descriptor metadata. A localhost mirror remains on the same machine. A remote mirror transmits and persists that Vault data on the remote server.
+
+Embedding/LLM provider API keys are never sent. The Companion bearer token is independent of those credentials and is stored in Obsidian plugin data within the security constraints of an Obsidian Community Plugin. There is no telemetry, account system, permissive browser CORS, MCP, agent, or Vault write-back in v0.

--- a/companion/eslint.config.mjs
+++ b/companion/eslint.config.mjs
@@ -1,0 +1,23 @@
+import eslint from "@eslint/js";
+import tseslint from "typescript-eslint";
+
+export default tseslint.config(
+  {
+    ignores: ["dist/**", "coverage/**"],
+  },
+  eslint.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    files: ["**/*.ts"],
+    languageOptions: {
+      parserOptions: {
+        project: ["./tsconfig.json", "./tsconfig.test.json"],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      "@typescript-eslint/explicit-function-return-type": "error",
+      "@typescript-eslint/no-explicit-any": "error"
+    },
+  },
+);

--- a/companion/package-lock.json
+++ b/companion/package-lock.json
@@ -8,15 +8,39 @@
       "name": "vault-audit-ai-companion",
       "version": "0.1.0",
       "devDependencies": {
-        "@eslint/js": "^9.39.5",
+        "@eslint/js": "^10.0.1",
         "@types/node": "^24.10.0",
-        "eslint": "^9.39.5",
+        "eslint": "^10.10.0",
         "typescript": "^5.9.3",
-        "typescript-eslint": "^8.67.0",
+        "typescript-eslint": "^8.69.0",
         "vitest": "^4.1.10"
       },
       "engines": {
         "node": ">=24.0.0"
+      }
+    },
+    "node_modules/@cacheable/memory": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.2.0.tgz",
+      "integrity": "sha512-CTLKqLItRCEixEAewD3/j9DB3/o96gpTPD4eJ1v+DGOlxZRZncRQkGYqqnAGCscYd6RNeXfGeiuCphsPtqyIfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cacheable/utils": "^2.5.0",
+        "@keyv/bigmap": "^1.3.1",
+        "hookified": "^1.15.1",
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@cacheable/utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.5.0.tgz",
+      "integrity": "sha512-buipgOVDkkPXNR5+xBpDw7Zk2n1EvU7qBJCNUcL7rhQ//kfpOXPAvQ511Os0vpLYJ1pZnvudNytkQt2hst3wqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hashery": "^1.5.1",
+        "keyv": "^5.6.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -62,105 +86,89 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
-      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^2.1.7",
+        "@eslint/object-schema": "^3.0.5",
         "debug": "^4.3.1",
-        "minimatch": "^3.1.5"
+        "minimatch": "^10.2.4"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
-      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
+      "integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.17.0"
+        "@eslint/core": "^1.2.1"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
-      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/eslintrc": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.7.tgz",
-      "integrity": "sha512-F42g89Qd5oAWtp0k0nnSrjziAKza7w8SVT4mStc18LZMaRb4J1HQAHLCalEtDCxrTuksx7NU9qsmeLwpOfPqWw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.14.0",
-        "debug": "^4.3.2",
-        "espree": "^10.0.1",
-        "globals": "^14.0.0",
-        "ignore": "^5.2.0",
-        "import-fresh": "^3.2.1",
-        "js-yaml": "^4.3.2",
-        "minimatch": "^3.1.5",
-        "strip-json-comments": "^3.1.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.39.5",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
-      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
-      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
-      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.3.tgz",
+      "integrity": "sha512-IkO+/KEUvwbVpiURZg+P7zF74z5Jxe0UgJxVni+RtoHQ6IZieXaO02kmadomap/q+l6bc/jdPGGqTjhuZnuz1Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.17.0",
+        "@eslint/core": "^1.2.1",
         "levn": "^0.4.1"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@humanfs/core": {
@@ -233,6 +241,30 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
       "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@keyv/bigmap": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.1.tgz",
+      "integrity": "sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hashery": "^1.4.0",
+        "hookified": "^1.15.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@keyv/serialize": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
+      "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
       "dev": true,
       "license": "MIT"
     },
@@ -551,6 +583,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -763,45 +802,6 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
-      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "10.2.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
-      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.8"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@typescript-eslint/utils": {
       "version": "8.69.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.69.0.tgz",
@@ -842,19 +842,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@vitest/expect": {
@@ -1010,29 +997,6 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0"
-    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1044,31 +1008,40 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/brace-expansion": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
-      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/callsites": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=6"
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/cacheable": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.5.0.tgz",
+      "integrity": "sha512-60cyAOytib/OzBw1JNSoSV/boK1AtHryDIjvVBk7XbN4ugfkM3+Sry7fEjNgPMGgOjuaZPAp8ruZ0Cxafwyq9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cacheable/memory": "^2.2.0",
+        "@cacheable/utils": "^2.5.0",
+        "hookified": "^1.15.0",
+        "keyv": "^5.6.0",
+        "qified": "^0.10.1"
       }
     },
     "node_modules/chai": {
@@ -1080,50 +1053,6 @@
       "engines": {
         "node": ">=18"
       }
-    },
-    "node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -1203,45 +1132,43 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.39.5",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
-      "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
-      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.10.0.tgz",
+      "integrity": "sha512-NPXn6r5zl4uET1DAVPaOwzX3rut4c0wcmw3dWJAfOsTM5+TogXo0DDjz8pwm/hL8cyVNpHqeK4JpN0NjnyFFNw==",
       "dev": true,
       "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
-        "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.21.2",
-        "@eslint/config-helpers": "^0.4.2",
-        "@eslint/core": "^0.17.0",
-        "@eslint/eslintrc": "^3.3.6",
-        "@eslint/js": "9.39.5",
-        "@eslint/plugin-kit": "^0.4.1",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.7.0",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.3",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
         "ajv": "^6.14.0",
-        "chalk": "^4.0.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.4.0",
-        "eslint-visitor-keys": "^4.2.1",
-        "espree": "^10.4.0",
-        "esquery": "^1.5.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
-        "file-entry-cache": "^8.0.0",
+        "file-entry-cache": "11.1.5 || >11.1.6 <12",
         "find-up": "^5.0.0",
         "glob-parent": "^6.0.2",
         "ignore": "^5.2.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.5",
+        "minimatch": "^10.2.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -1249,7 +1176,7 @@
         "eslint": "bin/eslint.js"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://eslint.org/donate"
@@ -1264,48 +1191,50 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
-      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/espree": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
-      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.15.0",
+        "acorn": "^8.16.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.1"
+        "eslint-visitor-keys": "^5.0.1"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -1417,16 +1346,13 @@
       }
     },
     "node_modules/file-entry-cache": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
-      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "version": "11.1.5",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.5.tgz",
+      "integrity": "sha512-+PFTHITI08JIGhnNpGNI8T8inUpgZfk3GNEqfT9R2zZV2iFXg3CvqzSl/uEhs7TSGujYRELEANyDvS8Fj7+S7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "flat-cache": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
+        "flat-cache": "^6.1.23"
       }
     },
     "node_modules/find-up": {
@@ -1447,17 +1373,15 @@
       }
     },
     "node_modules/flat-cache": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
-      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "version": "6.1.23",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.23.tgz",
+      "integrity": "sha512-f++BY9pTk+983xK1FLzlLpmM0i0z+jHmx3QESGkURMXujQZz1k5wzwX6hjnQ8goaD0B+sYnDK1yZ6MTyZfUaqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "flatted": "^3.2.9",
-        "keyv": "^4.5.4"
-      },
-      "engines": {
-        "node": ">=16"
+        "cacheable": "^2.5.0",
+        "flatted": "^3.4.2",
+        "hookified": "^1.15.0"
       }
     },
     "node_modules/flatted": {
@@ -1495,28 +1419,25 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/globals": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+    "node_modules/hashery": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/hashery/-/hashery-1.5.1.tgz",
+      "integrity": "sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">=18"
+      "dependencies": {
+        "hookified": "^1.15.0"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+      "engines": {
+        "node": ">=20"
       }
     },
-    "node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+    "node_modules/hookified": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz",
+      "integrity": "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
+      "license": "MIT"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -1526,23 +1447,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/import-fresh": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
-      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "parent-module": "^1.0.0",
-        "resolve-from": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/imurmurhash": {
@@ -1585,36 +1489,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/js-yaml": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
-      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/json-buffer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -1630,13 +1504,13 @@
       "license": "MIT"
     },
     "node_modules/keyv": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
-      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "json-buffer": "3.0.1"
+        "@keyv/serialize": "^1.1.1"
       }
     },
     "node_modules/levn": {
@@ -1942,13 +1816,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lodash.merge": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -1960,16 +1827,19 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
-        "node": "*"
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/ms": {
@@ -2069,19 +1939,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/parent-module": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "callsites": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -2178,15 +2035,25 @@
         "node": ">=6"
       }
     },
-    "node_modules/resolve-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+    "node_modules/qified": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/qified/-/qified-0.10.1.tgz",
+      "integrity": "sha512-+Owyggi9IxT1ePKGafcI87ubSmxol6smwJ+RAHDQlx9+9cPwFWDiKFFCPuWhr9ignlGpZ9vDQLw67N4dcTVFEA==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "hookified": "^2.1.1"
+      },
       "engines": {
-        "node": ">=4"
+        "node": ">=20"
       }
+    },
+    "node_modules/qified/node_modules/hookified": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-2.2.0.tgz",
+      "integrity": "sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/rolldown": {
       "version": "1.2.7",
@@ -2288,32 +2155,6 @@
       "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/strip-json-comments": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",

--- a/companion/package-lock.json
+++ b/companion/package-lock.json
@@ -1,0 +1,2668 @@
+{
+  "name": "vault-audit-ai-companion",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "vault-audit-ai-companion",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@eslint/js": "^9.39.5",
+        "@types/node": "^24.10.0",
+        "eslint": "^9.39.5",
+        "typescript": "^5.9.3",
+        "typescript-eslint": "^8.67.0",
+        "vitest": "^4.1.10"
+      },
+      "engines": {
+        "node": ">=24.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.7.tgz",
+      "integrity": "sha512-F42g89Qd5oAWtp0k0nnSrjziAKza7w8SVT4mStc18LZMaRb4J1HQAHLCalEtDCxrTuksx7NU9qsmeLwpOfPqWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.3.2",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+      "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.148.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.148.0.tgz",
+      "integrity": "sha512-Nm4s/jB+4FpFsPhWGEC4h7rzksesmtnMXomo6rCMcg/b8zLQuOziRgkCS1fxDCXOlJB/6Q8oABOZ/OP6RIPj9A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/oxc-project"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm-eabi": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.7.tgz",
+      "integrity": "sha512-EypzgnYCwyVY4NDHKzGmNJT5b+XaQEBniHxsMdeIQLB/tcCzZnhqrzHpZFbX9iaxx+5RiB8caATBtfvZP7zVxQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.7.tgz",
+      "integrity": "sha512-l17HE9EweWaqJZhuUuNBN/FzM62xw+DECVnJyvMsxn8vJFAGLy5QfLDoYAcronkAN8VxKZHezDpulHDPx95vFw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.7.tgz",
+      "integrity": "sha512-8ED8ELFvHXc6OCETIn4gXObPiaR6bckM/ipXtbzlPVDRMBfEGjCKgO90F9YtfdpDatVx/ZQw7aZ1vUMf/+T3Mw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.7.tgz",
+      "integrity": "sha512-/WPripjtiAIZ2tWY7ddijORT0Ujg87wxWW/qcoFVCKAWVDPhtY0xr7Dj0M3GyNGz60jGwTElhro/mkF9dT7dDQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.7.tgz",
+      "integrity": "sha512-14DI4NcqpvbICxSnGLx3PmtDaWqRP/KGSGb6C+JLLVPeZRl6dKdHba3pGsqT3vpdTqhEYIPG0MMQ8c0xYqoJxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.7.tgz",
+      "integrity": "sha512-bxrWIRvHWQvbJwi+VIie/kDJmQxcNE6xxWwZdqF/ExVAigtHkv54WTLQPb+QsZdnFy18fg7JPfWGL0RH6vwIlQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.7.tgz",
+      "integrity": "sha512-toOY2BChBZyuxU7OYX6Tn389di4IzAqPTycVcci0O7FSfBqzRB3RZn+K5Is6ANf4tmgRd/K1yZTsNTXbkXsnLg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.7.tgz",
+      "integrity": "sha512-lAIXTH/aiLRLxsTgQvfhjo4K1ydWIp00+V0voOr9beb/9ZmkUFrSIb03dXNFRgMNvkE6oGsF10ioQ6UsI+vS5Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.7.tgz",
+      "integrity": "sha512-kdnwS28Pkenp/mZMRwjXXXwxQ7pIsm+bF919LUK93BOyhcLsrVKdP2p9fxpiPNPAbNuch8ypQt0pm2P2LYCAGg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.7.tgz",
+      "integrity": "sha512-516OdsyLdr5E65paF3yBF55t8mfm9+gmtCsK3xI7XKXIT7EfRlHhxL8K/NR6Hu8BWSgF5+1w74lTL0+nxcc8Qw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.7.tgz",
+      "integrity": "sha512-r8/z8n7GFaYRln3xmP1Cxy0HH/HLM0uBUPkEuSVEfKGDA89M0FsZRZJRSwe/tJjRx+fpH/gjorfhB8tmEbSFLA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.7.tgz",
+      "integrity": "sha512-pAsE8iiDxUg1xBqdhrTfg45AVDVpirjz00sblEYClGNNcMnDb+e8beQgqIAw6LvauX/APvgxUnwrgun/YYGBhw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.7.tgz",
+      "integrity": "sha512-lTcIYmmnQQA8Or/2DatS6oSqcdLHvendjS+zLu+FwgToynWMRSmQdpM65fTANJgIS4mjbMOo5KT2lnT9SAb96w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.7.tgz",
+      "integrity": "sha512-e3Gu3WxbNk/UqQhxqU7YIYO+9ZBvWNz3U+h/qRFosscMFzdRPbXYSaSWgSnklv2fz1TgzBTcti2z35c/7irsHw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.7.tgz",
+      "integrity": "sha512-W/jg5qoRSqjsEv0+dZi4e687mcHqmVuU0P4fK6qS/xjetW2Gmc1W8j//z5nAeNcC8Ttm0hV46IjcYeuVwYhuiw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.69.0.tgz",
+      "integrity": "sha512-t5jQTKPIgVW1PE6dR6H6Qz5gm8zjMlX5/2gRaOGd9eO6V7J+tQc6iWKukEe7dY8u9HyYasQ0yfF0/FSSTEO2gA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.69.0",
+        "@typescript-eslint/type-utils": "8.69.0",
+        "@typescript-eslint/utils": "8.69.0",
+        "@typescript-eslint/visitor-keys": "8.69.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.69.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.8.tgz",
+      "integrity": "sha512-YYNsSlXBjMk92SKnkwvB5LOVSa6OznlFUGcsvrFgNJbJCd0M1XKeFVRc8ZByeCqz32FivYNHJVooLmdqrmvp/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.69.0.tgz",
+      "integrity": "sha512-l4b0DhWioGg6Gt2ebGlvfkFMOjRsauxtsnDRwUSRX1qHq3HdTfQHV8wW9zEXeciai6HfeaKOedQn2Zoofx3WBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.69.0",
+        "@typescript-eslint/types": "8.69.0",
+        "@typescript-eslint/typescript-estree": "8.69.0",
+        "@typescript-eslint/visitor-keys": "8.69.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.69.0.tgz",
+      "integrity": "sha512-yi4obFrHMmnsesWehHbkg9zMA7Jt8cXT+mKM08G999pH1yT6nqgsHx7MYm0uY1wAj8CqiBXYRJ7WAT0QdQHQXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.69.0",
+        "@typescript-eslint/types": "^8.69.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.69.0.tgz",
+      "integrity": "sha512-ewfspqWvSxKSOaplqAUNbaSFO0eB6w1EtQ+esfYFRm3614Ty4uNtExkcbgd6nWsXphbqKyf9ZYdbZdv2xEoWEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.69.0",
+        "@typescript-eslint/visitor-keys": "8.69.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.69.0.tgz",
+      "integrity": "sha512-xNqK7YTDZsLniQMV/4rpFR8Z5JlqeRvVjuG1YgF/mdPVH84HSD19L8CczMA0qg2RfwEV231GHH3VnToJDo4MfQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.69.0.tgz",
+      "integrity": "sha512-ZfoJAVg3JZndQEpEl9petVlxau3lRuElc4HRMuAlLCf8to04/iHz692RUSNmXKDjEuJmIL+KZ2/BsOcBc16dsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.69.0",
+        "@typescript-eslint/typescript-estree": "8.69.0",
+        "@typescript-eslint/utils": "8.69.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.69.0.tgz",
+      "integrity": "sha512-K3VrubUPhlo9VDBS6QdI8YB5j7ClpqLRdefcz6PFrhnwicehBweqQ9Evhl4l+FYz0HdDmMqIiSX0aldGRYtDCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.69.0.tgz",
+      "integrity": "sha512-AdFkgqck3Vudb/kWnxlyafU/4aBhHrbQ9locP2N4psXTy5mOBg0SHJumnLvx7r6g1gV4DKvUFwV2nJZBoqOD8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.69.0",
+        "@typescript-eslint/tsconfig-utils": "8.69.0",
+        "@typescript-eslint/types": "8.69.0",
+        "@typescript-eslint/visitor-keys": "8.69.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.69.0.tgz",
+      "integrity": "sha512-tUbx60BBqQa31kXF5MCsOOLL5E/WzUuxIn7YpAvq+eaUlqvk8/NXnXMBNAdLCr0icjkzem7iUA5QqWHe/hJ1aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.69.0",
+        "@typescript-eslint/types": "8.69.0",
+        "@typescript-eslint/typescript-estree": "8.69.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.69.0.tgz",
+      "integrity": "sha512-+rmdgPA+EXkNgKYvHvFfhrs35utXbwaC5PGpDquSXcoXQDKUA5UjV0LmTucG/4JXkM31BTu4TilHtrN8IVBe8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.69.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
+      "integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
+      "integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.11",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.11.tgz",
+      "integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.11",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
+      "integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.11.tgz",
+      "integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
+      "integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
+      "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
+      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.6",
+        "@eslint/js": "9.39.5",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+      "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.28",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.28.tgz",
+      "integrity": "sha512-RRuzqDtt5Y9h3quz5hWhK+TPnsmVs6WwSU6LkJMeY4HstUEDuYTG8UJSdawMRzmzAtV+KEoG8N3Qg2qLy5vM/A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.18",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.7.tgz",
+      "integrity": "sha512-g0EtLvBjTUB7jhyV0S/TCup3v/XSVl45vUIGbOGU4QPiyjTenCe4mKuFvW9fEgYmS2Fo42AUssRmNuMziXdrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.148.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm-eabi": "1.2.7",
+        "@rolldown/binding-android-arm64": "1.2.7",
+        "@rolldown/binding-darwin-arm64": "1.2.7",
+        "@rolldown/binding-darwin-x64": "1.2.7",
+        "@rolldown/binding-freebsd-x64": "1.2.7",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.7",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.7",
+        "@rolldown/binding-linux-arm64-musl": "1.2.7",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.7",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.7",
+        "@rolldown/binding-linux-x64-gnu": "1.2.7",
+        "@rolldown/binding-linux-x64-musl": "1.2.7",
+        "@rolldown/binding-openharmony-arm64": "1.2.7",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.7",
+        "@rolldown/binding-win32-x64-msvc": "1.2.7"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.1.tgz",
+      "integrity": "sha512-GCvB3aoys96IuDFBMcTB46JOR6mdMtAToqwiW8JlWhsoh1mhHi/xn9ss/Dg7N555GiJyEt2qzoG/NHCwM6h1EA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.69.0.tgz",
+      "integrity": "sha512-B3MltX0VqjUBNEe3b3sSuiRbfa6XrfHFtBiPamjT5AsW/dfq+y+bc0wyuS9DxAS1LyzCxRp2+rxzpLUvqM2BvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.69.0",
+        "@typescript-eslint/parser": "8.69.0",
+        "@typescript-eslint/typescript-estree": "8.69.0",
+        "@typescript-eslint/utils": "8.69.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.2.tgz",
+      "integrity": "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.26",
+        "rolldown": "~1.2.4",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.4.0 || ^0.5.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz",
+      "integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.11",
+        "@vitest/mocker": "4.1.11",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/runner": "4.1.11",
+        "@vitest/snapshot": "4.1.11",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.11",
+        "@vitest/browser-preview": "4.1.11",
+        "@vitest/browser-webdriverio": "4.1.11",
+        "@vitest/coverage-istanbul": "4.1.11",
+        "@vitest/coverage-v8": "4.1.11",
+        "@vitest/ui": "4.1.11",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/companion/package.json
+++ b/companion/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "vault-audit-ai-companion",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Standalone persistent semantic mirror for Vault Audit AI",
+  "engines": {
+    "node": ">=24.0.0"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "lint": "eslint . --max-warnings 0",
+    "start": "node --env-file-if-exists=.env dist/server.js",
+    "test": "vitest run",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.39.5",
+    "@types/node": "^24.10.0",
+    "eslint": "^9.39.5",
+    "typescript": "^5.9.3",
+    "typescript-eslint": "^8.67.0",
+    "vitest": "^4.1.10"
+  }
+}

--- a/companion/package.json
+++ b/companion/package.json
@@ -15,11 +15,11 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "devDependencies": {
-    "@eslint/js": "^9.39.5",
+    "@eslint/js": "^10.0.1",
     "@types/node": "^24.10.0",
-    "eslint": "^9.39.5",
+    "eslint": "^10.10.0",
     "typescript": "^5.9.3",
-    "typescript-eslint": "^8.67.0",
+    "typescript-eslint": "^8.69.0",
     "vitest": "^4.1.10"
   }
 }

--- a/companion/src/auth.ts
+++ b/companion/src/auth.ts
@@ -1,0 +1,17 @@
+import { createHash, timingSafeEqual } from "node:crypto";
+
+function digest(value: string): Buffer {
+  return createHash("sha256").update(value, "utf8").digest();
+}
+
+export function bearerToken(header: string | string[] | undefined): string | null {
+  if (typeof header !== "string") return null;
+  const match = /^Bearer ([^\s]+)$/u.exec(header);
+  return match?.[1] ?? null;
+}
+
+export function isAuthorized(header: string | string[] | undefined, expected: string): boolean {
+  const supplied = bearerToken(header);
+  if (supplied === null) return false;
+  return timingSafeEqual(digest(supplied), digest(expected));
+}

--- a/companion/src/config.ts
+++ b/companion/src/config.ts
@@ -1,0 +1,74 @@
+import { isIP } from "node:net";
+import { resolve } from "node:path";
+
+export type LogLevel = "debug" | "info" | "warn" | "error";
+
+export interface CompanionConfig {
+  host: string;
+  port: number;
+  token: string;
+  dataDir: string;
+  allowRemoteBind: boolean;
+  logLevel: LogLevel;
+  bodyLimitBytes: number;
+}
+
+export class ConfigurationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ConfigurationError";
+  }
+}
+
+function booleanValue(value: string | undefined, fallback: boolean, name: string): boolean {
+  if (value === undefined || value === "") return fallback;
+  if (value === "true") return true;
+  if (value === "false") return false;
+  throw new ConfigurationError(`${name} must be true or false.`);
+}
+
+function validHostname(host: string): boolean {
+  if (host === "localhost" || isIP(host)) return true;
+  if (host.length > 253 || host.includes("..")) return false;
+  return host.split(".").every((label) =>
+    /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$/u.test(label),
+  );
+}
+
+export function isLoopbackHost(host: string): boolean {
+  if (host.toLowerCase() === "localhost" || host === "::1") return true;
+  if (isIP(host) === 4) return host.startsWith("127.");
+  return false;
+}
+
+export function loadConfig(environment: NodeJS.ProcessEnv = process.env): CompanionConfig {
+  const host = environment.HOST?.trim() || "127.0.0.1";
+  if (!validHostname(host)) throw new ConfigurationError("HOST must be a valid IP address or hostname.");
+  const rawPort = environment.PORT?.trim() || "27124";
+  if (!/^\d+$/u.test(rawPort)) throw new ConfigurationError("PORT must be an integer from 1 to 65535.");
+  const port = Number(rawPort);
+  if (!Number.isSafeInteger(port) || port < 1 || port > 65_535) {
+    throw new ConfigurationError("PORT must be an integer from 1 to 65535.");
+  }
+  const token = environment.COMPANION_TOKEN?.trim() ?? "";
+  if (!token) throw new ConfigurationError("COMPANION_TOKEN must be a non-empty secret.");
+  const allowRemoteBind = booleanValue(environment.ALLOW_REMOTE_BIND, false, "ALLOW_REMOTE_BIND");
+  if (!isLoopbackHost(host) && !allowRemoteBind) {
+    throw new ConfigurationError("Non-loopback HOST requires ALLOW_REMOTE_BIND=true.");
+  }
+  const dataDirRaw = environment.DATA_DIR?.trim() || "./data";
+  if (dataDirRaw.includes("\0")) throw new ConfigurationError("DATA_DIR is invalid.");
+  const level = environment.LOG_LEVEL?.trim() || "info";
+  if (!(["debug", "info", "warn", "error"] as const).includes(level as LogLevel)) {
+    throw new ConfigurationError("LOG_LEVEL must be debug, info, warn, or error.");
+  }
+  return {
+    host,
+    port,
+    token,
+    dataDir: resolve(dataDirRaw),
+    allowRemoteBind,
+    logLevel: level as LogLevel,
+    bodyLimitBytes: 16 * 1024 * 1024,
+  };
+}

--- a/companion/src/logging/logger.ts
+++ b/companion/src/logging/logger.ts
@@ -1,0 +1,51 @@
+import type { LogLevel } from "../config.js";
+
+export interface Logger {
+  debug(message: string, context?: Record<string, unknown>): void;
+  info(message: string, context?: Record<string, unknown>): void;
+  warn(message: string, context?: Record<string, unknown>): void;
+  error(message: string, context?: Record<string, unknown>): void;
+}
+
+const LEVELS: Record<LogLevel, number> = { debug: 10, info: 20, warn: 30, error: 40 };
+
+export function redact(value: unknown, secrets: readonly string[]): unknown {
+  if (typeof value === "string") {
+    let result = value.replace(/Bearer\s+[^\s"']+/giu, "Bearer [REDACTED]");
+    for (const secret of secrets) {
+      if (secret) result = result.split(secret).join("[REDACTED]");
+    }
+    return result;
+  }
+  if (Array.isArray(value)) return value.map((item) => redact(item, secrets));
+  if (value && typeof value === "object") {
+    const output: Record<string, unknown> = {};
+    for (const [key, item] of Object.entries(value)) {
+      output[key] = /authorization|token|api.?key|secret/iu.test(key)
+        ? "[REDACTED]"
+        : redact(item, secrets);
+    }
+    return output;
+  }
+  return value;
+}
+
+export function createLogger(level: LogLevel, secrets: readonly string[] = []): Logger {
+  const threshold = LEVELS[level];
+  const write = (candidate: LogLevel, message: string, context?: Record<string, unknown>): void => {
+    if (LEVELS[candidate] < threshold) return;
+    const entry: Record<string, unknown> = {
+      time: new Date().toISOString(),
+      level: candidate,
+      message: redact(message, secrets),
+    };
+    if (context) entry.context = redact(context, secrets);
+    process[candidate === "debug" ? "stdout" : candidate === "info" ? "stdout" : "stderr"].write(`${JSON.stringify(entry)}\n`);
+  };
+  return {
+    debug: (message, context) => write("debug", message, context),
+    info: (message, context) => write("info", message, context),
+    warn: (message, context) => write("warn", message, context),
+    error: (message, context) => write("error", message, context),
+  };
+}

--- a/companion/src/protocol/errors.ts
+++ b/companion/src/protocol/errors.ts
@@ -1,0 +1,32 @@
+export type ProtocolErrorCode =
+  | "AUTH_REQUIRED"
+  | "PROTOCOL_VERSION_MISMATCH"
+  | "MALFORMED_JSON"
+  | "INVALID_REQUEST"
+  | "REQUEST_TOO_LARGE"
+  | "NOT_FOUND"
+  | "METHOD_NOT_ALLOWED"
+  | "DESCRIPTOR_MISMATCH"
+  | "STALE_GENERATION"
+  | "STORAGE_ERROR"
+  | "INTERNAL_ERROR";
+
+export class ProtocolError extends Error {
+  constructor(
+    readonly status: number,
+    readonly code: ProtocolErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ProtocolError";
+  }
+}
+
+export function publicError(error: unknown): ProtocolError {
+  if (error instanceof ProtocolError) return error;
+  return new ProtocolError(
+    500,
+    "INTERNAL_ERROR",
+    "The Companion could not complete the request.",
+  );
+}

--- a/companion/src/protocol/schemas.ts
+++ b/companion/src/protocol/schemas.ts
@@ -1,0 +1,247 @@
+import { ProtocolError } from "./errors.js";
+import { PROTOCOL_VERSION } from "./types.js";
+import type {
+  ChunkSourceRange,
+  MirroredChunk,
+  MirroredNote,
+  NoteManifestEntry,
+  ReconciliationPlanRequest,
+  SemanticDescriptor,
+  SyncBatchRequest,
+  SyncOperation,
+} from "./types.js";
+
+export const MAX_BATCH_OPERATIONS = 100;
+export const MAX_MANIFEST_NOTES = 100_000;
+export const MAX_NOTE_CONTENT_BYTES = 4 * 1024 * 1024;
+export const MAX_CHUNKS_PER_NOTE = 10_000;
+
+function invalid(message: string): never {
+  throw new ProtocolError(400, "INVALID_REQUEST", message);
+}
+
+function record(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    invalid(`${label} must be an object.`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function stringValue(value: unknown, label: string, max = 16_384): string {
+  if (typeof value !== "string" || value.length === 0 || value.length > max) {
+    invalid(`${label} must be a non-empty string of at most ${max} characters.`);
+  }
+  return value;
+}
+
+function integer(value: unknown, label: string, minimum = 0): number {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < minimum) {
+    invalid(`${label} must be a safe integer greater than or equal to ${minimum}.`);
+  }
+  return value;
+}
+
+function protocolVersion(value: unknown): 1 {
+  if (value !== PROTOCOL_VERSION) {
+    throw new ProtocolError(
+      409,
+      "PROTOCOL_VERSION_MISMATCH",
+      `Companion protocol version ${PROTOCOL_VERSION} is required.`,
+    );
+  }
+  return PROTOCOL_VERSION;
+}
+
+export function validateVaultId(value: string): string {
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu.test(value)) {
+    invalid("vaultId must be a UUID.");
+  }
+  return value.toLowerCase();
+}
+
+export function validateVaultPath(value: unknown, label = "path"): string {
+  const path = stringValue(value, label, 4096);
+  if (
+    path !== path.trim() ||
+    path.includes("\0") ||
+    path.includes("\\") ||
+    path.startsWith("/") ||
+    /^[A-Za-z]:[\\/]/u.test(path) ||
+    path.split("/").some((part) => !part || part === "." || part === "..")
+  ) {
+    invalid(`${label} must be a canonical vault-relative path.`);
+  }
+  return path;
+}
+
+function descriptor(value: unknown): SemanticDescriptor {
+  const input = record(value, "descriptor");
+  const baseUrl = stringValue(input.baseUrl, "descriptor.baseUrl", 4096);
+  let parsed: URL;
+  try {
+    parsed = new URL(baseUrl);
+  } catch {
+    invalid("descriptor.baseUrl must be a valid URL.");
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    invalid("descriptor.baseUrl must use HTTP or HTTPS.");
+  }
+  if (parsed.username || parsed.password) {
+    invalid("descriptor.baseUrl must not contain credentials.");
+  }
+  if (input.normalized !== true) invalid("descriptor.normalized must be true.");
+  return {
+    providerId: stringValue(input.providerId, "descriptor.providerId", 256),
+    model: stringValue(input.model, "descriptor.model", 1024),
+    baseUrl,
+    dimensions: integer(input.dimensions, "descriptor.dimensions", 1),
+    embeddingSpaceId: stringValue(input.embeddingSpaceId, "descriptor.embeddingSpaceId", 8192),
+    normalized: true,
+  };
+}
+
+function source(value: unknown): ChunkSourceRange {
+  const input = record(value, "chunk.source");
+  const result = {
+    startOffset: integer(input.startOffset, "chunk.source.startOffset"),
+    endOffset: integer(input.endOffset, "chunk.source.endOffset"),
+    startLine: integer(input.startLine, "chunk.source.startLine"),
+    endLine: integer(input.endLine, "chunk.source.endLine"),
+  };
+  if (result.startOffset > result.endOffset || result.startLine > result.endLine) {
+    invalid("chunk.source range is reversed.");
+  }
+  return result;
+}
+
+function chunk(value: unknown, notePath: string, dimensions: number): MirroredChunk {
+  const input = record(value, "chunk");
+  if (!Array.isArray(input.headingPath) || input.headingPath.some((item) => typeof item !== "string")) {
+    invalid("chunk.headingPath must be an array of strings.");
+  }
+  if (!Array.isArray(input.embedding) || input.embedding.length !== dimensions) {
+    invalid(`chunk.embedding must contain exactly ${dimensions} values.`);
+  }
+  const embedding = input.embedding.map((item) => {
+    if (typeof item !== "number" || !Number.isFinite(item)) {
+      invalid("chunk.embedding values must be finite numbers.");
+    }
+    return item;
+  });
+  const actualPath = validateVaultPath(input.notePath, "chunk.notePath");
+  if (actualPath !== notePath) invalid("chunk.notePath must match note.path.");
+  return {
+    chunkId: stringValue(input.chunkId, "chunk.chunkId", 4096),
+    notePath: actualPath,
+    ordinal: integer(input.ordinal, "chunk.ordinal"),
+    headingPath: [...(input.headingPath as string[])],
+    text: typeof input.text === "string" ? input.text : invalid("chunk.text must be a string."),
+    contentHash: stringValue(input.contentHash, "chunk.contentHash", 1024),
+    source: source(input.source),
+    embedding,
+  };
+}
+
+function note(value: unknown, dimensions: number): MirroredNote {
+  const input = record(value, "note");
+  const path = validateVaultPath(input.path, "note.path");
+  if (typeof input.content !== "string") invalid("note.content must be a string.");
+  if (Buffer.byteLength(input.content as string, "utf8") > MAX_NOTE_CONTENT_BYTES) {
+    invalid(`note.content exceeds ${MAX_NOTE_CONTENT_BYTES} bytes.`);
+  }
+  const metadata = record(input.metadata, "note.metadata");
+  if (!Array.isArray(input.chunks) || input.chunks.length > MAX_CHUNKS_PER_NOTE) {
+    invalid(`note.chunks must contain at most ${MAX_CHUNKS_PER_NOTE} entries.`);
+  }
+  const chunks = input.chunks.map((item) => chunk(item, path, dimensions));
+  const ids = new Set<string>();
+  const ordinals = new Set<number>();
+  for (const item of chunks) {
+    if (ids.has(item.chunkId)) invalid("note.chunks contains duplicate chunkId values.");
+    if (ordinals.has(item.ordinal)) invalid("note.chunks contains duplicate ordinal values.");
+    if (item.source.endOffset > (input.content as string).length) {
+      invalid("chunk.source must be within note.content.");
+    }
+    ids.add(item.chunkId);
+    ordinals.add(item.ordinal);
+  }
+  return {
+    path,
+    content: input.content as string,
+    contentHash: stringValue(input.contentHash, "note.contentHash", 1024),
+    metadata,
+    chunks,
+  };
+}
+
+function manifestEntry(value: unknown): NoteManifestEntry {
+  const input = record(value, "manifest note");
+  if (!Array.isArray(input.chunks) || input.chunks.length > MAX_CHUNKS_PER_NOTE) {
+    invalid(`manifest chunks must contain at most ${MAX_CHUNKS_PER_NOTE} entries.`);
+  }
+  const chunks = input.chunks.map((value) => {
+    const item = record(value, "manifest chunk");
+    return {
+      chunkId: stringValue(item.chunkId, "manifest chunkId", 4096),
+      contentHash: stringValue(item.contentHash, "manifest chunk contentHash", 1024),
+    };
+  });
+  return {
+    path: validateVaultPath(input.path),
+    contentHash: stringValue(input.contentHash, "manifest contentHash", 1024),
+    chunks,
+  };
+}
+
+export function parseReconciliationPlanRequest(value: unknown): ReconciliationPlanRequest {
+  const input = record(value, "request");
+  protocolVersion(input.protocolVersion);
+  if (!Array.isArray(input.notes) || input.notes.length > MAX_MANIFEST_NOTES) {
+    invalid(`notes must contain at most ${MAX_MANIFEST_NOTES} entries.`);
+  }
+  const notes = input.notes.map(manifestEntry);
+  const paths = new Set<string>();
+  for (const item of notes) {
+    if (paths.has(item.path)) invalid("notes contains duplicate paths.");
+    paths.add(item.path);
+  }
+  return {
+    protocolVersion: PROTOCOL_VERSION,
+    generation: integer(input.generation, "generation"),
+    descriptor: descriptor(input.descriptor),
+    notes,
+  };
+}
+
+function operation(value: unknown, dimensions: number): SyncOperation {
+  const input = record(value, "operation");
+  if (input.type === "UPSERT") return { type: "UPSERT", note: note(input.note, dimensions) };
+  if (input.type === "DELETE") return { type: "DELETE", path: validateVaultPath(input.path) };
+  if (input.type === "RENAME") {
+    const renamed = note(input.note, dimensions);
+    const oldPath = validateVaultPath(input.oldPath, "oldPath");
+    if (oldPath === renamed.path) invalid("RENAME paths must differ.");
+    return { type: "RENAME", oldPath, note: renamed };
+  }
+  invalid("operation.type must be UPSERT, DELETE, or RENAME.");
+}
+
+export function parseSyncBatchRequest(value: unknown): SyncBatchRequest {
+  const input = record(value, "request");
+  protocolVersion(input.protocolVersion);
+  const parsedDescriptor = descriptor(input.descriptor);
+  if (!Array.isArray(input.operations) || input.operations.length > MAX_BATCH_OPERATIONS) {
+    invalid(`operations must contain at most ${MAX_BATCH_OPERATIONS} entries.`);
+  }
+  if (input.replaceVault !== undefined && typeof input.replaceVault !== "boolean") {
+    invalid("replaceVault must be a boolean.");
+  }
+  const result: SyncBatchRequest = {
+    protocolVersion: PROTOCOL_VERSION,
+    generation: integer(input.generation, "generation"),
+    descriptor: parsedDescriptor,
+    operations: input.operations.map((item) => operation(item, parsedDescriptor.dimensions)),
+  };
+  if (input.replaceVault !== undefined) result.replaceVault = input.replaceVault;
+  return result;
+}

--- a/companion/src/protocol/types.ts
+++ b/companion/src/protocol/types.ts
@@ -1,0 +1,104 @@
+export const PROTOCOL_VERSION = 1 as const;
+export const PROTOCOL_HEADER = "x-companion-protocol-version";
+
+export interface SemanticDescriptor {
+  providerId: string;
+  model: string;
+  baseUrl: string;
+  dimensions: number;
+  embeddingSpaceId: string;
+  normalized: true;
+}
+
+export interface ChunkSourceRange {
+  startOffset: number;
+  endOffset: number;
+  startLine: number;
+  endLine: number;
+}
+
+export interface NoteManifestEntry {
+  path: string;
+  contentHash: string;
+  chunks: Array<{ chunkId: string; contentHash: string }>;
+}
+
+export interface MirroredChunk {
+  chunkId: string;
+  notePath: string;
+  ordinal: number;
+  headingPath: string[];
+  text: string;
+  contentHash: string;
+  source: ChunkSourceRange;
+  embedding: number[];
+}
+
+export interface MirroredNote {
+  path: string;
+  content: string;
+  contentHash: string;
+  metadata: Record<string, unknown>;
+  chunks: MirroredChunk[];
+}
+
+export interface ReconciliationPlanRequest {
+  protocolVersion: typeof PROTOCOL_VERSION;
+  generation: number;
+  descriptor: SemanticDescriptor;
+  notes: NoteManifestEntry[];
+}
+
+export interface ReconciliationPlanResponse {
+  protocolVersion: typeof PROTOCOL_VERSION;
+  generation: number;
+  serverGeneration: number;
+  replaceVault: boolean;
+  uploadPaths: string[];
+  deletePaths: string[];
+  unchangedPaths: string[];
+}
+
+export type SyncOperation =
+  | { type: "UPSERT"; note: MirroredNote }
+  | { type: "DELETE"; path: string }
+  | { type: "RENAME"; oldPath: string; note: MirroredNote };
+
+export interface SyncBatchRequest {
+  protocolVersion: typeof PROTOCOL_VERSION;
+  generation: number;
+  descriptor: SemanticDescriptor;
+  replaceVault?: boolean;
+  operations: SyncOperation[];
+}
+
+export interface SyncBatchResponse {
+  protocolVersion: typeof PROTOCOL_VERSION;
+  generation: number;
+  applied: boolean;
+  stale: boolean;
+  operationsApplied: number;
+}
+
+export interface ServerStatus {
+  status: "ok";
+  protocolVersion: typeof PROTOCOL_VERSION;
+  vaultCount: number;
+}
+
+export interface VaultStatus {
+  protocolVersion: typeof PROTOCOL_VERSION;
+  vaultId: string;
+  exists: boolean;
+  generation: number;
+  noteCount: number;
+  chunkCount: number;
+  descriptor: SemanticDescriptor | null;
+}
+
+export interface ErrorResponse {
+  error: {
+    code: string;
+    message: string;
+  };
+}

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -1,0 +1,189 @@
+import { createServer } from "node:http";
+import type { IncomingMessage, Server, ServerResponse } from "node:http";
+import { pathToFileURL } from "node:url";
+import { isAuthorized } from "./auth.js";
+import { loadConfig } from "./config.js";
+import type { CompanionConfig } from "./config.js";
+import { createLogger } from "./logging/logger.js";
+import type { Logger } from "./logging/logger.js";
+import { ProtocolError, publicError } from "./protocol/errors.js";
+import {
+  parseReconciliationPlanRequest,
+  parseSyncBatchRequest,
+  validateVaultId,
+} from "./protocol/schemas.js";
+import {
+  PROTOCOL_HEADER,
+  PROTOCOL_VERSION,
+} from "./protocol/types.js";
+import type { ErrorResponse } from "./protocol/types.js";
+import type { CompanionStorage } from "./storage/companionStorage.js";
+import { SqliteCompanionStorage } from "./storage/sqliteCompanionStorage.js";
+import { ReconciliationService } from "./sync/reconciliation.js";
+
+function sendJson(response: ServerResponse, status: number, value: unknown): void {
+  const body = JSON.stringify(value);
+  response.writeHead(status, {
+    "content-type": "application/json; charset=utf-8",
+    "content-length": Buffer.byteLength(body),
+    "cache-control": "no-store",
+    "x-content-type-options": "nosniff",
+  });
+  response.end(body);
+}
+
+function sendError(response: ServerResponse, error: unknown, logger: Logger): void {
+  const normalized = publicError(error);
+  if (normalized.status >= 500) {
+    logger.error("Request failed.", { code: normalized.code });
+  }
+  const body: ErrorResponse = {
+    error: { code: normalized.code, message: normalized.message },
+  };
+  sendJson(response, normalized.status, body);
+}
+
+async function readJson(request: IncomingMessage, limit: number): Promise<unknown> {
+  const contentType = request.headers["content-type"]?.split(";", 1)[0]?.trim().toLowerCase();
+  if (contentType !== "application/json") {
+    throw new ProtocolError(400, "INVALID_REQUEST", "Content-Type must be application/json.");
+  }
+  const chunks: Buffer[] = [];
+  let bytes = 0;
+  let oversized = false;
+  for await (const raw of request) {
+    const chunk = Buffer.isBuffer(raw) ? raw : Buffer.from(raw as Uint8Array);
+    bytes += chunk.byteLength;
+    if (bytes > limit) {
+      oversized = true;
+      continue;
+    }
+    chunks.push(chunk);
+  }
+  if (oversized) throw new ProtocolError(413, "REQUEST_TOO_LARGE", "Request body exceeds the configured limit.");
+  if (bytes === 0) throw new ProtocolError(400, "MALFORMED_JSON", "A JSON request body is required.");
+  try {
+    return JSON.parse(Buffer.concat(chunks).toString("utf8")) as unknown;
+  } catch {
+    throw new ProtocolError(400, "MALFORMED_JSON", "Request body is not valid JSON.");
+  }
+}
+
+function checkVersion(request: IncomingMessage): void {
+  const supplied = request.headers[PROTOCOL_HEADER];
+  if (supplied !== String(PROTOCOL_VERSION)) {
+    throw new ProtocolError(
+      409,
+      "PROTOCOL_VERSION_MISMATCH",
+      `Companion protocol version ${PROTOCOL_VERSION} is required.`,
+    );
+  }
+}
+
+function methodNotAllowed(): never {
+  throw new ProtocolError(405, "METHOD_NOT_ALLOWED", "The HTTP method is not supported for this route.");
+}
+
+async function routeRequest(
+  request: IncomingMessage,
+  response: ServerResponse,
+  config: CompanionConfig,
+  storage: CompanionStorage,
+  reconciliation: ReconciliationService,
+): Promise<void> {
+  const url = new URL(request.url ?? "/", "http://companion.invalid");
+  if (url.pathname === "/health") {
+    if (request.method !== "GET") methodNotAllowed();
+    sendJson(response, 200, { status: "ok", protocolVersion: PROTOCOL_VERSION });
+    return;
+  }
+  if (!url.pathname.startsWith("/v1/")) {
+    throw new ProtocolError(404, "NOT_FOUND", "Route not found.");
+  }
+  if (!isAuthorized(request.headers.authorization, config.token)) {
+    throw new ProtocolError(401, "AUTH_REQUIRED", "Valid Bearer authentication is required.");
+  }
+  checkVersion(request);
+
+  if (url.pathname === "/v1/status") {
+    if (request.method !== "GET") methodNotAllowed();
+    const status = await storage.getServerStatus();
+    sendJson(response, 200, { status: "ok", protocolVersion: PROTOCOL_VERSION, vaultCount: status.vaultCount });
+    return;
+  }
+
+  const match = /^\/v1\/vaults\/([^/]+)\/(status|reconcile\/plan|sync\/batch)$/u.exec(url.pathname);
+  if (!match?.[1] || !match[2]) throw new ProtocolError(404, "NOT_FOUND", "Route not found.");
+  const vaultId = validateVaultId(decodeURIComponent(match[1]));
+  const action = match[2];
+  if (action === "status") {
+    if (request.method !== "GET") methodNotAllowed();
+    sendJson(response, 200, await storage.getVaultStatus(vaultId));
+    return;
+  }
+  if (request.method !== "POST") methodNotAllowed();
+  const body = await readJson(request, config.bodyLimitBytes);
+  if (action === "reconcile/plan") {
+    sendJson(response, 200, await reconciliation.plan(vaultId, parseReconciliationPlanRequest(body)));
+    return;
+  }
+  sendJson(response, 200, await reconciliation.apply(vaultId, parseSyncBatchRequest(body)));
+}
+
+export function createCompanionServer(
+  config: CompanionConfig,
+  storage: CompanionStorage,
+  logger: Logger = createLogger(config.logLevel, [config.token]),
+): Server {
+  const reconciliation = new ReconciliationService(storage);
+  return createServer((request, response) => {
+    void routeRequest(request, response, config, storage, reconciliation).catch((error: unknown) => {
+      if (!response.headersSent) sendError(response, error, logger);
+      else response.destroy();
+    });
+  });
+}
+
+export async function startCompanion(
+  config: CompanionConfig = loadConfig(),
+  logger: Logger = createLogger(config.logLevel, [config.token]),
+): Promise<{ server: Server; storage: CompanionStorage }> {
+  const storage = new SqliteCompanionStorage(config.dataDir);
+  await storage.initialize();
+  const server = createCompanionServer(config, storage, logger);
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(config.port, config.host, () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  logger.info("Vault Audit AI Companion started.", {
+    host: config.host,
+    port: config.port,
+    protocolVersion: PROTOCOL_VERSION,
+  });
+  return { server, storage };
+}
+
+async function main(): Promise<void> {
+  let started: Awaited<ReturnType<typeof startCompanion>>;
+  try {
+    started = await startCompanion();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Companion startup failed.";
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 1;
+    return;
+  }
+  const shutdown = (): void => {
+    started.server.close(() => {
+      void started.storage.close().finally(() => process.exit(0));
+    });
+  };
+  process.once("SIGINT", shutdown);
+  process.once("SIGTERM", shutdown);
+}
+
+const entry = process.argv[1];
+if (entry && import.meta.url === pathToFileURL(entry).href) void main();

--- a/companion/src/storage/companionStorage.ts
+++ b/companion/src/storage/companionStorage.ts
@@ -1,0 +1,31 @@
+import type {
+  MirroredNote,
+  NoteManifestEntry,
+  ReconciliationPlanResponse,
+  SemanticDescriptor,
+  SyncBatchRequest,
+  SyncBatchResponse,
+  VaultStatus,
+} from "../protocol/types.js";
+
+export interface StoredVaultSnapshot {
+  vaultId: string;
+  generation: number;
+  descriptor: SemanticDescriptor;
+  notes: MirroredNote[];
+}
+
+export interface CompanionStorage {
+  initialize(): Promise<void>;
+  close(): Promise<void>;
+  getServerStatus(): Promise<{ vaultCount: number }>;
+  getVaultStatus(vaultId: string): Promise<VaultStatus>;
+  planReconciliation(
+    vaultId: string,
+    generation: number,
+    descriptor: SemanticDescriptor,
+    notes: readonly NoteManifestEntry[],
+  ): Promise<ReconciliationPlanResponse>;
+  applyBatch(vaultId: string, batch: SyncBatchRequest): Promise<SyncBatchResponse>;
+  readVault(vaultId: string): Promise<StoredVaultSnapshot | null>;
+}

--- a/companion/src/storage/migrations.ts
+++ b/companion/src/storage/migrations.ts
@@ -1,0 +1,75 @@
+import type { DatabaseSync } from "node:sqlite";
+
+interface Migration {
+  version: number;
+  sql: string;
+}
+
+export const MIGRATIONS: readonly Migration[] = [
+  {
+    version: 1,
+    sql: `
+      CREATE TABLE IF NOT EXISTS vaults (
+        vault_id TEXT PRIMARY KEY NOT NULL,
+        protocol_version INTEGER NOT NULL,
+        generation INTEGER NOT NULL,
+        descriptor_json TEXT NOT NULL,
+        embedding_space_id TEXT NOT NULL,
+        dimensions INTEGER NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      ) STRICT;
+
+      CREATE TABLE IF NOT EXISTS notes (
+        vault_id TEXT NOT NULL,
+        path TEXT NOT NULL,
+        content TEXT NOT NULL,
+        content_hash TEXT NOT NULL,
+        metadata_json TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        PRIMARY KEY (vault_id, path),
+        FOREIGN KEY (vault_id) REFERENCES vaults(vault_id) ON DELETE CASCADE
+      ) STRICT;
+
+      CREATE TABLE IF NOT EXISTS chunks (
+        vault_id TEXT NOT NULL,
+        chunk_id TEXT NOT NULL,
+        note_path TEXT NOT NULL,
+        ordinal INTEGER NOT NULL,
+        heading_path_json TEXT NOT NULL,
+        text TEXT NOT NULL,
+        content_hash TEXT NOT NULL,
+        source_start_offset INTEGER NOT NULL,
+        source_end_offset INTEGER NOT NULL,
+        source_start_line INTEGER NOT NULL,
+        source_end_line INTEGER NOT NULL,
+        embedding BLOB NOT NULL,
+        PRIMARY KEY (vault_id, chunk_id),
+        UNIQUE (vault_id, note_path, ordinal),
+        FOREIGN KEY (vault_id, note_path) REFERENCES notes(vault_id, path) ON DELETE CASCADE
+      ) STRICT;
+
+      CREATE INDEX IF NOT EXISTS chunks_by_note
+        ON chunks(vault_id, note_path, ordinal, chunk_id);
+    `,
+  },
+];
+
+export function runMigrations(database: DatabaseSync): void {
+  database.exec("PRAGMA foreign_keys = ON");
+  const row = database.prepare("PRAGMA user_version").get() as { user_version: number };
+  let version = row.user_version;
+  for (const migration of MIGRATIONS) {
+    if (migration.version <= version) continue;
+    database.exec("BEGIN IMMEDIATE");
+    try {
+      database.exec(migration.sql);
+      database.exec(`PRAGMA user_version = ${migration.version}`);
+      database.exec("COMMIT");
+      version = migration.version;
+    } catch (error) {
+      database.exec("ROLLBACK");
+      throw error;
+    }
+  }
+}

--- a/companion/src/storage/sqliteCompanionStorage.ts
+++ b/companion/src/storage/sqliteCompanionStorage.ts
@@ -1,0 +1,391 @@
+import { mkdir, access } from "node:fs/promises";
+import { constants } from "node:fs";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { ProtocolError } from "../protocol/errors.js";
+import { PROTOCOL_VERSION } from "../protocol/types.js";
+import type {
+  MirroredChunk,
+  MirroredNote,
+  NoteManifestEntry,
+  ReconciliationPlanResponse,
+  SemanticDescriptor,
+  SyncBatchRequest,
+  SyncBatchResponse,
+  SyncOperation,
+  VaultStatus,
+} from "../protocol/types.js";
+import type { CompanionStorage, StoredVaultSnapshot } from "./companionStorage.js";
+import { runMigrations } from "./migrations.js";
+
+interface VaultRow {
+  vault_id: string;
+  generation: number;
+  descriptor_json: string;
+  embedding_space_id: string;
+  dimensions: number;
+}
+
+interface NoteRow {
+  path: string;
+  content: string;
+  content_hash: string;
+  metadata_json: string;
+}
+
+interface ChunkRow {
+  chunk_id: string;
+  note_path: string;
+  ordinal: number;
+  heading_path_json: string;
+  text: string;
+  content_hash: string;
+  source_start_offset: number;
+  source_end_offset: number;
+  source_start_line: number;
+  source_end_line: number;
+  embedding: Uint8Array;
+}
+
+function compareStrings(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function descriptorEqual(left: SemanticDescriptor, right: SemanticDescriptor): boolean {
+  return (
+    left.providerId === right.providerId &&
+    left.model === right.model &&
+    left.baseUrl === right.baseUrl &&
+    left.dimensions === right.dimensions &&
+    left.embeddingSpaceId === right.embeddingSpaceId &&
+    left.normalized === right.normalized
+  );
+}
+
+function encodeVector(values: readonly number[]): Buffer {
+  const output = Buffer.allocUnsafe(values.length * 4);
+  for (let index = 0; index < values.length; index++) output.writeFloatLE(values[index] ?? 0, index * 4);
+  return output;
+}
+
+function decodeVector(value: Uint8Array, dimensions: number): number[] {
+  const bytes = Buffer.from(value.buffer, value.byteOffset, value.byteLength);
+  if (bytes.byteLength !== dimensions * 4) {
+    throw new ProtocolError(500, "STORAGE_ERROR", "Stored embedding dimensions are invalid.");
+  }
+  const result: number[] = [];
+  for (let index = 0; index < dimensions; index++) result.push(bytes.readFloatLE(index * 4));
+  return result;
+}
+
+function parseDescriptor(row: VaultRow): SemanticDescriptor {
+  try {
+    return JSON.parse(row.descriptor_json) as SemanticDescriptor;
+  } catch {
+    throw new ProtocolError(500, "STORAGE_ERROR", "Stored descriptor is invalid.");
+  }
+}
+
+function parseJsonRecord(value: string): Record<string, unknown> {
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : {};
+  } catch {
+    throw new ProtocolError(500, "STORAGE_ERROR", "Stored note metadata is invalid.");
+  }
+}
+
+function parseStringArray(value: string): string[] {
+  try {
+    const parsed: unknown = JSON.parse(value);
+    if (Array.isArray(parsed) && parsed.every((item) => typeof item === "string")) return parsed;
+  } catch {
+    // Normalized to a public storage error below.
+  }
+  throw new ProtocolError(500, "STORAGE_ERROR", "Stored chunk metadata is invalid.");
+}
+
+export class SqliteCompanionStorage implements CompanionStorage {
+  private database: DatabaseSync | null = null;
+
+  constructor(private readonly dataDir: string, private readonly filename = "companion.sqlite") {}
+
+  async initialize(): Promise<void> {
+    if (this.database) return;
+    try {
+      await mkdir(this.dataDir, { recursive: true });
+      await access(this.dataDir, constants.R_OK | constants.W_OK);
+      const database = new DatabaseSync(join(this.dataDir, this.filename), { timeout: 5_000 });
+      database.exec("PRAGMA journal_mode = WAL");
+      database.exec("PRAGMA synchronous = FULL");
+      runMigrations(database);
+      this.database = database;
+    } catch {
+      throw new ProtocolError(500, "STORAGE_ERROR", "Companion DATA_DIR is not accessible or SQLite initialization failed.");
+    }
+  }
+
+  async close(): Promise<void> {
+    this.database?.close();
+    this.database = null;
+  }
+
+  async getServerStatus(): Promise<{ vaultCount: number }> {
+    const row = this.db().prepare("SELECT COUNT(*) AS count FROM vaults").get() as { count: number };
+    return { vaultCount: row.count };
+  }
+
+  async getVaultStatus(vaultId: string): Promise<VaultStatus> {
+    const row = this.vaultRow(vaultId);
+    if (!row) {
+      return {
+        protocolVersion: PROTOCOL_VERSION,
+        vaultId,
+        exists: false,
+        generation: 0,
+        noteCount: 0,
+        chunkCount: 0,
+        descriptor: null,
+      };
+    }
+    const counts = this.db().prepare(`
+      SELECT
+        (SELECT COUNT(*) FROM notes WHERE vault_id = ?) AS note_count,
+        (SELECT COUNT(*) FROM chunks WHERE vault_id = ?) AS chunk_count
+    `).get(vaultId, vaultId) as { note_count: number; chunk_count: number };
+    return {
+      protocolVersion: PROTOCOL_VERSION,
+      vaultId,
+      exists: true,
+      generation: row.generation,
+      noteCount: counts.note_count,
+      chunkCount: counts.chunk_count,
+      descriptor: parseDescriptor(row),
+    };
+  }
+
+  async planReconciliation(
+    vaultId: string,
+    generation: number,
+    descriptor: SemanticDescriptor,
+    notes: readonly NoteManifestEntry[],
+  ): Promise<ReconciliationPlanResponse> {
+    const existingVault = this.vaultRow(vaultId);
+    if (existingVault && generation < existingVault.generation) {
+      throw new ProtocolError(409, "STALE_GENERATION", "Incoming semantic generation is older than the stored mirror.");
+    }
+    const storedNotes = this.noteManifest(vaultId);
+    const incoming = [...notes].sort((left, right) => compareStrings(left.path, right.path));
+    const incompatible = Boolean(existingVault && !descriptorEqual(parseDescriptor(existingVault), descriptor));
+    const uploadPaths: string[] = [];
+    const unchangedPaths: string[] = [];
+    const incomingPaths = new Set(incoming.map((note) => note.path));
+
+    for (const note of incoming) {
+      const stored = storedNotes.get(note.path);
+      const equal = !incompatible && stored !== undefined && stored.contentHash === note.contentHash &&
+        stored.chunks.length === note.chunks.length &&
+        stored.chunks.every((chunk, index) => {
+          const candidate = note.chunks[index];
+          return candidate?.chunkId === chunk.chunkId && candidate.contentHash === chunk.contentHash;
+        });
+      (equal ? unchangedPaths : uploadPaths).push(note.path);
+    }
+    const deletePaths = [...storedNotes.keys()]
+      .filter((path) => incompatible || !incomingPaths.has(path))
+      .sort(compareStrings);
+    return {
+      protocolVersion: PROTOCOL_VERSION,
+      generation,
+      serverGeneration: existingVault?.generation ?? 0,
+      replaceVault: incompatible,
+      uploadPaths,
+      deletePaths,
+      unchangedPaths,
+    };
+  }
+
+  async applyBatch(vaultId: string, batch: SyncBatchRequest): Promise<SyncBatchResponse> {
+    const database = this.db();
+    const current = this.vaultRow(vaultId);
+    if (current && batch.generation < current.generation) {
+      return {
+        protocolVersion: PROTOCOL_VERSION,
+        generation: current.generation,
+        applied: false,
+        stale: true,
+        operationsApplied: 0,
+      };
+    }
+    if (current && !batch.replaceVault && !descriptorEqual(parseDescriptor(current), batch.descriptor)) {
+      throw new ProtocolError(409, "DESCRIPTOR_MISMATCH", "Incoming vectors use a different semantic descriptor.");
+    }
+    database.exec("BEGIN IMMEDIATE");
+    try {
+      if (batch.replaceVault) database.prepare("DELETE FROM vaults WHERE vault_id = ?").run(vaultId);
+      this.upsertVault(vaultId, batch);
+      for (const operation of batch.operations) this.applyOperation(vaultId, operation);
+      database.exec("COMMIT");
+    } catch (error) {
+      database.exec("ROLLBACK");
+      if (error instanceof ProtocolError) throw error;
+      throw new ProtocolError(500, "STORAGE_ERROR", "The synchronization batch could not be committed.");
+    }
+    return {
+      protocolVersion: PROTOCOL_VERSION,
+      generation: batch.generation,
+      applied: true,
+      stale: false,
+      operationsApplied: batch.operations.length,
+    };
+  }
+
+  async readVault(vaultId: string): Promise<StoredVaultSnapshot | null> {
+    const vault = this.vaultRow(vaultId);
+    if (!vault) return null;
+    const notes = this.db().prepare(`
+      SELECT path, content, content_hash, metadata_json
+      FROM notes WHERE vault_id = ? ORDER BY path
+    `).all(vaultId) as unknown as NoteRow[];
+    const chunks = this.db().prepare(`
+      SELECT chunk_id, note_path, ordinal, heading_path_json, text, content_hash,
+             source_start_offset, source_end_offset, source_start_line, source_end_line, embedding
+      FROM chunks WHERE vault_id = ? ORDER BY note_path, ordinal, chunk_id
+    `).all(vaultId) as unknown as ChunkRow[];
+    const descriptor = parseDescriptor(vault);
+    const chunksByPath = new Map<string, MirroredChunk[]>();
+    for (const row of chunks) {
+      const values = chunksByPath.get(row.note_path) ?? [];
+      values.push({
+        chunkId: row.chunk_id,
+        notePath: row.note_path,
+        ordinal: row.ordinal,
+        headingPath: parseStringArray(row.heading_path_json),
+        text: row.text,
+        contentHash: row.content_hash,
+        source: {
+          startOffset: row.source_start_offset,
+          endOffset: row.source_end_offset,
+          startLine: row.source_start_line,
+          endLine: row.source_end_line,
+        },
+        embedding: decodeVector(row.embedding, descriptor.dimensions),
+      });
+      chunksByPath.set(row.note_path, values);
+    }
+    return {
+      vaultId,
+      generation: vault.generation,
+      descriptor,
+      notes: notes.map((row) => ({
+        path: row.path,
+        content: row.content,
+        contentHash: row.content_hash,
+        metadata: parseJsonRecord(row.metadata_json),
+        chunks: chunksByPath.get(row.path) ?? [],
+      })),
+    };
+  }
+
+  private db(): DatabaseSync {
+    if (!this.database) throw new ProtocolError(500, "STORAGE_ERROR", "Storage has not been initialized.");
+    return this.database;
+  }
+
+  private vaultRow(vaultId: string): VaultRow | null {
+    return (this.db().prepare(`
+      SELECT vault_id, generation, descriptor_json, embedding_space_id, dimensions
+      FROM vaults WHERE vault_id = ?
+    `).get(vaultId) as VaultRow | undefined) ?? null;
+  }
+
+  private noteManifest(vaultId: string): Map<string, NoteManifestEntry> {
+    const notes = this.db().prepare(`
+      SELECT path, content_hash FROM notes WHERE vault_id = ? ORDER BY path
+    `).all(vaultId) as unknown as Array<{ path: string; content_hash: string }>;
+    const chunks = this.db().prepare(`
+      SELECT note_path, chunk_id, content_hash
+      FROM chunks WHERE vault_id = ? ORDER BY note_path, ordinal, chunk_id
+    `).all(vaultId) as unknown as Array<{ note_path: string; chunk_id: string; content_hash: string }>;
+    const result = new Map<string, NoteManifestEntry>();
+    for (const note of notes) result.set(note.path, { path: note.path, contentHash: note.content_hash, chunks: [] });
+    for (const chunk of chunks) result.get(chunk.note_path)?.chunks.push({ chunkId: chunk.chunk_id, contentHash: chunk.content_hash });
+    return result;
+  }
+
+  private upsertVault(vaultId: string, batch: SyncBatchRequest): void {
+    const now = new Date().toISOString();
+    this.db().prepare(`
+      INSERT INTO vaults (
+        vault_id, protocol_version, generation, descriptor_json,
+        embedding_space_id, dimensions, created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(vault_id) DO UPDATE SET
+        protocol_version = excluded.protocol_version,
+        generation = MAX(vaults.generation, excluded.generation),
+        descriptor_json = excluded.descriptor_json,
+        embedding_space_id = excluded.embedding_space_id,
+        dimensions = excluded.dimensions,
+        updated_at = excluded.updated_at
+    `).run(
+      vaultId,
+      PROTOCOL_VERSION,
+      batch.generation,
+      JSON.stringify(batch.descriptor),
+      batch.descriptor.embeddingSpaceId,
+      batch.descriptor.dimensions,
+      now,
+      now,
+    );
+  }
+
+  private applyOperation(vaultId: string, operation: SyncOperation): void {
+    if (operation.type === "DELETE") {
+      this.db().prepare("DELETE FROM notes WHERE vault_id = ? AND path = ?").run(vaultId, operation.path);
+      return;
+    }
+    if (operation.type === "RENAME") {
+      this.db().prepare("DELETE FROM notes WHERE vault_id = ? AND path IN (?, ?)").run(
+        vaultId,
+        operation.oldPath,
+        operation.note.path,
+      );
+      this.insertNote(vaultId, operation.note);
+      return;
+    }
+    this.db().prepare("DELETE FROM notes WHERE vault_id = ? AND path = ?").run(vaultId, operation.note.path);
+    this.insertNote(vaultId, operation.note);
+  }
+
+  private insertNote(vaultId: string, note: MirroredNote): void {
+    this.db().prepare(`
+      INSERT INTO notes (vault_id, path, content, content_hash, metadata_json, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `).run(vaultId, note.path, note.content, note.contentHash, JSON.stringify(note.metadata), new Date().toISOString());
+    const insert = this.db().prepare(`
+      INSERT INTO chunks (
+        vault_id, chunk_id, note_path, ordinal, heading_path_json, text,
+        content_hash, source_start_offset, source_end_offset,
+        source_start_line, source_end_line, embedding
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+    for (const chunk of note.chunks) {
+      insert.run(
+        vaultId,
+        chunk.chunkId,
+        note.path,
+        chunk.ordinal,
+        JSON.stringify(chunk.headingPath),
+        chunk.text,
+        chunk.contentHash,
+        chunk.source.startOffset,
+        chunk.source.endOffset,
+        chunk.source.startLine,
+        chunk.source.endLine,
+        encodeVector(chunk.embedding),
+      );
+    }
+  }
+}

--- a/companion/src/sync/reconciliation.ts
+++ b/companion/src/sync/reconciliation.ts
@@ -1,0 +1,24 @@
+import type { CompanionStorage } from "../storage/companionStorage.js";
+import type {
+  ReconciliationPlanRequest,
+  ReconciliationPlanResponse,
+  SyncBatchRequest,
+  SyncBatchResponse,
+} from "../protocol/types.js";
+
+export class ReconciliationService {
+  constructor(private readonly storage: CompanionStorage) {}
+
+  plan(vaultId: string, request: ReconciliationPlanRequest): Promise<ReconciliationPlanResponse> {
+    return this.storage.planReconciliation(
+      vaultId,
+      request.generation,
+      request.descriptor,
+      request.notes,
+    );
+  }
+
+  apply(vaultId: string, request: SyncBatchRequest): Promise<SyncBatchResponse> {
+    return this.storage.applyBatch(vaultId, request);
+  }
+}

--- a/companion/tests/config.test.ts
+++ b/companion/tests/config.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { ConfigurationError, isLoopbackHost, loadConfig } from "../src/config.js";
+
+function environment(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  return { COMPANION_TOKEN: "test-secret", ...overrides };
+}
+
+describe("Companion configuration", () => {
+  it("uses a loopback-only default", () => {
+    expect(loadConfig(environment())).toMatchObject({ host: "127.0.0.1", port: 27124, allowRemoteBind: false });
+  });
+
+  it.each(["0", "65536", "12.5", "abc"])("rejects invalid port %s", (port) => {
+    expect(() => loadConfig(environment({ PORT: port }))).toThrow(ConfigurationError);
+  });
+
+  it("rejects an empty token", () => {
+    expect(() => loadConfig({ COMPANION_TOKEN: "  " })).toThrow(/COMPANION_TOKEN/u);
+  });
+
+  it("rejects an invalid host", () => {
+    expect(() => loadConfig(environment({ HOST: "https://bad host/" }))).toThrow(/HOST/u);
+  });
+
+  it("rejects a non-loopback bind without explicit permission", () => {
+    expect(() => loadConfig(environment({ HOST: "0.0.0.0" }))).toThrow(/ALLOW_REMOTE_BIND/u);
+  });
+
+  it("accepts a non-loopback bind with explicit permission", () => {
+    expect(loadConfig(environment({ HOST: "0.0.0.0", ALLOW_REMOTE_BIND: "true" })).host).toBe("0.0.0.0");
+  });
+
+  it("recognizes IPv4 and IPv6 loopback only", () => {
+    expect(isLoopbackHost("127.42.0.1")).toBe(true);
+    expect(isLoopbackHost("::1")).toBe(true);
+    expect(isLoopbackHost("192.168.1.2")).toBe(false);
+  });
+});

--- a/companion/tests/fixtures.ts
+++ b/companion/tests/fixtures.ts
@@ -1,0 +1,50 @@
+import type { MirroredNote, SemanticDescriptor, SyncBatchRequest } from "../src/protocol/types.js";
+import { PROTOCOL_VERSION } from "../src/protocol/types.js";
+
+export const VAULT_A = "11111111-1111-4111-8111-111111111111";
+export const VAULT_B = "22222222-2222-4222-8222-222222222222";
+
+export function descriptor(overrides: Partial<SemanticDescriptor> = {}): SemanticDescriptor {
+  return {
+    providerId: "openai-compatible",
+    model: "text-embedding-test",
+    baseUrl: "https://embed.example/v1",
+    dimensions: 3,
+    embeddingSpaceId: "embedding-space:v1|provider=openai-compatible|model=text-embedding-test|endpoint=https%3A%2F%2Fembed.example%2Fv1|dimensions=3",
+    normalized: true,
+    ...overrides,
+  };
+}
+
+export function note(path = "A.md", content = "# A\n\nAlpha", vector = [0.25, -0.5, 0.75]): MirroredNote {
+  return {
+    path,
+    content,
+    contentHash: `note-${content}`,
+    metadata: { test: true },
+    chunks: [{
+      chunkId: `chunk-${path}-${content}`,
+      notePath: path,
+      ordinal: 0,
+      headingPath: [path.replace(/\.md$/u, "")],
+      text: `${path.replace(/\.md$/u, "")}\n\n${content.split("\n").at(-1) ?? ""}`,
+      contentHash: `chunk-hash-${content}`,
+      source: { startOffset: 0, endOffset: content.length, startLine: 0, endLine: 2 },
+      embedding: vector,
+    }],
+  };
+}
+
+export function upsertBatch(
+  generation: number,
+  notes: MirroredNote[],
+  overrides: Partial<SyncBatchRequest> = {},
+): SyncBatchRequest {
+  return {
+    protocolVersion: PROTOCOL_VERSION,
+    generation,
+    descriptor: descriptor(),
+    operations: notes.map((value) => ({ type: "UPSERT" as const, note: value })),
+    ...overrides,
+  };
+}

--- a/companion/tests/logging.test.ts
+++ b/companion/tests/logging.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { redact } from "../src/logging/logger.js";
+
+describe("structured log redaction", () => {
+  it("redacts configured secrets, bearer values, and sensitive keys recursively", () => {
+    const secret = "companion-super-secret";
+    const value = redact({
+      message: `failed for ${secret}`,
+      Authorization: `Bearer ${secret}`,
+      nested: { token: secret, apiKey: "provider-key" },
+    }, [secret]);
+    const serialized = JSON.stringify(value);
+    expect(serialized).not.toContain(secret);
+    expect(serialized).not.toContain("provider-key");
+    expect(serialized).toContain("[REDACTED]");
+  });
+});

--- a/companion/tests/selfContained.test.ts
+++ b/companion/tests/selfContained.test.ts
@@ -1,0 +1,40 @@
+import { readFile, readdir } from "node:fs/promises";
+import { dirname, relative, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+async function typescriptFiles(directory: string): Promise<string[]> {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const nested = await Promise.all(entries.map((entry) => {
+    if (entry.isDirectory() && ["node_modules", "dist", "coverage"].includes(entry.name)) return [];
+    const path = resolve(directory, entry.name);
+    if (entry.isDirectory()) return typescriptFiles(path);
+    return entry.isFile() && entry.name.endsWith(".ts") ? [path] : [];
+  }));
+  return nested.flat();
+}
+
+describe("self-contained deployment boundary", () => {
+  it("has no TypeScript import that escapes companion", async () => {
+    const root = resolve(import.meta.dirname, "..");
+    const files = await typescriptFiles(root);
+    const violations: string[] = [];
+    const pattern = /(?:from\s+|import\s*\()\s*["'](\.\.?\/[^"']+)["']/gu;
+    for (const file of files) {
+      const source = await readFile(file, "utf8");
+      for (const match of source.matchAll(pattern)) {
+        const specifier = match[1];
+        if (!specifier) continue;
+        const target = resolve(dirname(file), specifier);
+        if (relative(root, target).startsWith("..")) violations.push(`${relative(root, file)} -> ${specifier}`);
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+
+  it("has no package dependency on a parent path", async () => {
+    const root = resolve(import.meta.dirname, "..");
+    for (const filename of ["package.json", "package-lock.json"]) {
+      expect(await readFile(resolve(root, filename), "utf8")).not.toMatch(/(?:file:|link:)\.\.\//u);
+    }
+  });
+});

--- a/companion/tests/server.test.ts
+++ b/companion/tests/server.test.ts
@@ -1,0 +1,153 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Server } from "node:http";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CompanionConfig } from "../src/config.js";
+import type { Logger } from "../src/logging/logger.js";
+import { PROTOCOL_HEADER, PROTOCOL_VERSION } from "../src/protocol/types.js";
+import { createCompanionServer } from "../src/server.js";
+import { SqliteCompanionStorage } from "../src/storage/sqliteCompanionStorage.js";
+import { descriptor, note, VAULT_A } from "./fixtures.js";
+
+describe("Companion HTTP API", () => {
+  const token = "server-test-super-secret";
+  let directory: string;
+  let storage: SqliteCompanionStorage;
+  let server: Server;
+  let baseUrl: string;
+  let logger: Logger;
+  let logMessages: string[];
+
+  beforeEach(async () => {
+    directory = await mkdtemp(join(tmpdir(), "vault-companion-http-"));
+    storage = new SqliteCompanionStorage(directory);
+    await storage.initialize();
+    logMessages = [];
+    logger = {
+      debug: vi.fn((message) => logMessages.push(message)),
+      info: vi.fn((message) => logMessages.push(message)),
+      warn: vi.fn((message) => logMessages.push(message)),
+      error: vi.fn((message, context) => logMessages.push(`${message}${JSON.stringify(context ?? {})}`)),
+    };
+    const config: CompanionConfig = {
+      host: "127.0.0.1",
+      port: 27124,
+      token,
+      dataDir: directory,
+      allowRemoteBind: false,
+      logLevel: "debug",
+      bodyLimitBytes: 4096,
+    };
+    server = createCompanionServer(config, storage, logger);
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    await storage.close();
+    await rm(directory, { recursive: true, force: true });
+  });
+
+  function headers(overrides: Record<string, string> = {}): Record<string, string> {
+    return {
+      authorization: `Bearer ${token}`,
+      [PROTOCOL_HEADER]: String(PROTOCOL_VERSION),
+      "content-type": "application/json",
+      ...overrides,
+    };
+  }
+
+  it("exposes only minimal unauthenticated health data", async () => {
+    const response = await fetch(`${baseUrl}/health`);
+    expect(response.status).toBe(200);
+    expect(response.headers.get("access-control-allow-origin")).toBeNull();
+    expect(await response.json()).toEqual({ status: "ok", protocolVersion: 1 });
+  });
+
+  it.each([
+    ["missing", {}],
+    ["invalid", { authorization: "Bearer wrong" }],
+  ])("returns 401 for %s authentication", async (_label, supplied) => {
+    const response = await fetch(`${baseUrl}/v1/status`, { headers: { [PROTOCOL_HEADER]: "1", ...supplied } });
+    expect(response.status).toBe(401);
+    expect(await response.json()).toMatchObject({ error: { code: "AUTH_REQUIRED" } });
+  });
+
+  it("accepts valid authentication", async () => {
+    const response = await fetch(`${baseUrl}/v1/status`, { headers: headers() });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ status: "ok", protocolVersion: 1, vaultCount: 0 });
+  });
+
+  it("rejects an incompatible protocol explicitly", async () => {
+    const response = await fetch(`${baseUrl}/v1/status`, { headers: headers({ [PROTOCOL_HEADER]: "2" }) });
+    expect(response.status).toBe(409);
+    expect(await response.json()).toMatchObject({ error: { code: "PROTOCOL_VERSION_MISMATCH" } });
+  });
+
+  it("rejects malformed JSON with a stable code and no stack trace", async () => {
+    const response = await fetch(`${baseUrl}/v1/vaults/${VAULT_A}/sync/batch`, {
+      method: "POST",
+      headers: headers(),
+      body: "{bad",
+    });
+    const body = JSON.stringify(await response.json());
+    expect(response.status).toBe(400);
+    expect(body).toContain("MALFORMED_JSON");
+    expect(body).not.toContain(" at ");
+  });
+
+  it("rejects malformed payloads", async () => {
+    const response = await fetch(`${baseUrl}/v1/vaults/${VAULT_A}/sync/batch`, {
+      method: "POST",
+      headers: headers(),
+      body: JSON.stringify({ protocolVersion: 1 }),
+    });
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({ error: { code: "INVALID_REQUEST" } });
+  });
+
+  it("rejects oversized bodies", async () => {
+    const response = await fetch(`${baseUrl}/v1/vaults/${VAULT_A}/sync/batch`, {
+      method: "POST",
+      headers: headers(),
+      body: JSON.stringify({ padding: "x".repeat(5000) }),
+    });
+    expect(response.status).toBe(413);
+    expect(await response.json()).toMatchObject({ error: { code: "REQUEST_TOO_LARGE" } });
+  });
+
+  it("supports reconciliation, transactional batch sync, and vault status", async () => {
+    const value = note();
+    const manifest = [{ path: value.path, contentHash: value.contentHash, chunks: value.chunks.map((chunk) => ({ chunkId: chunk.chunkId, contentHash: chunk.contentHash })) }];
+    const planResponse = await fetch(`${baseUrl}/v1/vaults/${VAULT_A}/reconcile/plan`, {
+      method: "POST",
+      headers: headers(),
+      body: JSON.stringify({ protocolVersion: 1, generation: 1, descriptor: descriptor(), notes: manifest }),
+    });
+    expect(await planResponse.json()).toMatchObject({ uploadPaths: ["A.md"], deletePaths: [] });
+
+    const batchResponse = await fetch(`${baseUrl}/v1/vaults/${VAULT_A}/sync/batch`, {
+      method: "POST",
+      headers: headers(),
+      body: JSON.stringify({ protocolVersion: 1, generation: 1, descriptor: descriptor(), operations: [{ type: "UPSERT", note: value }] }),
+    });
+    expect(await batchResponse.json()).toMatchObject({ applied: true, operationsApplied: 1 });
+
+    const statusResponse = await fetch(`${baseUrl}/v1/vaults/${VAULT_A}/status`, { headers: headers() });
+    expect(await statusResponse.json()).toMatchObject({ exists: true, noteCount: 1, chunkCount: 1, generation: 1 });
+  });
+
+  it("never includes the token or Authorization header in errors or logs", async () => {
+    const response = await fetch(`${baseUrl}/v1/not-found`, { headers: headers() });
+    const body = await response.text();
+    expect(body).not.toContain(token);
+    expect(body).not.toContain("Authorization");
+    expect(logMessages.join("\n")).not.toContain(token);
+    expect(logMessages.join("\n")).not.toContain("Authorization");
+  });
+});

--- a/companion/tests/storage.test.ts
+++ b/companion/tests/storage.test.ts
@@ -1,0 +1,177 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ProtocolError } from "../src/protocol/errors.js";
+import { PROTOCOL_VERSION } from "../src/protocol/types.js";
+import type { SyncBatchRequest } from "../src/protocol/types.js";
+import { SqliteCompanionStorage } from "../src/storage/sqliteCompanionStorage.js";
+import { descriptor, note, upsertBatch, VAULT_A, VAULT_B } from "./fixtures.js";
+
+describe("SQLite Companion storage", () => {
+  let directory: string;
+  let storage: SqliteCompanionStorage;
+
+  beforeEach(async () => {
+    directory = await mkdtemp(join(tmpdir(), "vault-companion-storage-"));
+    storage = new SqliteCompanionStorage(directory);
+    await storage.initialize();
+  });
+
+  afterEach(async () => {
+    await storage.close();
+    await rm(directory, { recursive: true, force: true });
+  });
+
+  it("initializes cleanly and idempotently", async () => {
+    await storage.initialize();
+    expect(await storage.getServerStatus()).toEqual({ vaultCount: 0 });
+  });
+
+  it("upserts notes and chunks and preserves Float32 vectors exactly", async () => {
+    const original = note();
+    await storage.applyBatch(VAULT_A, upsertBatch(1, [original]));
+    const snapshot = await storage.readVault(VAULT_A);
+    expect(snapshot?.notes[0]).toMatchObject({ path: "A.md", content: original.content });
+    expect(snapshot?.notes[0]?.chunks[0]?.embedding).toEqual(
+      Array.from(new Float32Array(original.chunks[0]!.embedding)),
+    );
+  });
+
+  it("makes repeated UPSERT idempotent", async () => {
+    const batch = upsertBatch(1, [note()]);
+    await storage.applyBatch(VAULT_A, batch);
+    await storage.applyBatch(VAULT_A, batch);
+    expect(await storage.getVaultStatus(VAULT_A)).toMatchObject({ noteCount: 1, chunkCount: 1 });
+  });
+
+  it("DELETE cascades to chunks", async () => {
+    await storage.applyBatch(VAULT_A, upsertBatch(1, [note()]));
+    await storage.applyBatch(VAULT_A, { ...upsertBatch(2, []), operations: [{ type: "DELETE", path: "A.md" }] });
+    expect(await storage.getVaultStatus(VAULT_A)).toMatchObject({ noteCount: 0, chunkCount: 0 });
+  });
+
+  it("RENAME atomically removes the old path", async () => {
+    await storage.applyBatch(VAULT_A, upsertBatch(1, [note()]));
+    const renamed = note("Folder/B.md", "# B\n\nBeta");
+    const batch: SyncBatchRequest = {
+      ...upsertBatch(2, []),
+      operations: [{ type: "RENAME", oldPath: "A.md", note: renamed }],
+    };
+    await storage.applyBatch(VAULT_A, batch);
+    await storage.applyBatch(VAULT_A, batch);
+    expect((await storage.readVault(VAULT_A))?.notes.map((item) => item.path)).toEqual(["Folder/B.md"]);
+    expect(await storage.getVaultStatus(VAULT_A)).toMatchObject({ noteCount: 1, chunkCount: 1 });
+  });
+
+  it("rolls back every operation when a batch fails", async () => {
+    await storage.applyBatch(VAULT_A, upsertBatch(1, [note()]));
+    const duplicate = note("C.md", "# C\n\nGamma");
+    duplicate.chunks[0]!.chunkId = "duplicate";
+    const collision = note("D.md", "# D\n\nDelta");
+    collision.chunks[0]!.chunkId = "duplicate";
+    await expect(storage.applyBatch(VAULT_A, upsertBatch(2, [duplicate, collision]))).rejects.toMatchObject({ code: "STORAGE_ERROR" });
+    expect((await storage.readVault(VAULT_A))?.notes.map((item) => item.path)).toEqual(["A.md"]);
+  });
+
+  it("isolates identical note and chunk identities by vaultId", async () => {
+    await storage.applyBatch(VAULT_A, upsertBatch(1, [note()]));
+    await storage.applyBatch(VAULT_B, upsertBatch(1, [note()]));
+    await storage.applyBatch(VAULT_A, { ...upsertBatch(2, []), operations: [{ type: "DELETE", path: "A.md" }] });
+    expect((await storage.readVault(VAULT_A))?.notes).toEqual([]);
+    expect((await storage.readVault(VAULT_B))?.notes).toHaveLength(1);
+  });
+
+  it("survives close and reopen with idempotent migrations", async () => {
+    await storage.applyBatch(VAULT_A, upsertBatch(7, [note()]));
+    await storage.close();
+    storage = new SqliteCompanionStorage(directory);
+    await storage.initialize();
+    await storage.initialize();
+    expect(await storage.getVaultStatus(VAULT_A)).toMatchObject({ generation: 7, noteCount: 1, chunkCount: 1 });
+  });
+
+  it("rejects incompatible vectors unless reconciliation explicitly replaces the vault", async () => {
+    await storage.applyBatch(VAULT_A, upsertBatch(1, [note()]));
+    const incompatible = descriptor({ model: "other", embeddingSpaceId: "other-space" });
+    await expect(storage.applyBatch(VAULT_A, { ...upsertBatch(2, []), descriptor: incompatible })).rejects.toMatchObject({ code: "DESCRIPTOR_MISMATCH" });
+    await storage.applyBatch(VAULT_A, {
+      ...upsertBatch(2, [note("B.md")]),
+      descriptor: incompatible,
+      replaceVault: true,
+    });
+    expect((await storage.readVault(VAULT_A))?.notes.map((item) => item.path)).toEqual(["B.md"]);
+  });
+
+  it("ignores a stale batch instead of overwriting a newer generation", async () => {
+    await storage.applyBatch(VAULT_A, upsertBatch(5, [note("New.md")]));
+    const result = await storage.applyBatch(VAULT_A, upsertBatch(4, [note("Old.md")]));
+    expect(result).toMatchObject({ applied: false, stale: true, generation: 5 });
+    expect((await storage.readVault(VAULT_A))?.notes.map((item) => item.path)).toEqual(["New.md"]);
+  });
+
+  it("plans missing, changed, stale, and unchanged paths deterministically", async () => {
+    const a = note("A.md", "a");
+    const b = note("B.md", "b");
+    const stale = note("Z.md", "z");
+    await storage.applyBatch(VAULT_A, upsertBatch(1, [a, b, stale]));
+    const changedB = note("B.md", "changed");
+    const missingC = note("C.md", "c");
+    const manifest = [missingC, changedB, a].map((item) => ({
+      path: item.path,
+      contentHash: item.contentHash,
+      chunks: item.chunks.map((chunk) => ({ chunkId: chunk.chunkId, contentHash: chunk.contentHash })),
+    }));
+    const plan = await storage.planReconciliation(VAULT_A, 2, descriptor(), manifest);
+    expect(plan).toMatchObject({ uploadPaths: ["B.md", "C.md"], deletePaths: ["Z.md"], unchangedPaths: ["A.md"], replaceVault: false });
+  });
+
+  it("makes reconciliation a no-op after convergence", async () => {
+    const value = note();
+    await storage.applyBatch(VAULT_A, upsertBatch(1, [value]));
+    const manifest = [{ path: value.path, contentHash: value.contentHash, chunks: value.chunks.map((chunk) => ({ chunkId: chunk.chunkId, contentHash: chunk.contentHash })) }];
+    const plan = await storage.planReconciliation(VAULT_A, 1, descriptor(), manifest);
+    expect(plan).toMatchObject({ uploadPaths: [], deletePaths: [], unchangedPaths: ["A.md"] });
+  });
+
+  it("handles an empty manifest deterministically", async () => {
+    expect(await storage.planReconciliation(VAULT_A, 0, descriptor(), [])).toMatchObject({
+      serverGeneration: 0,
+      uploadPaths: [],
+      deletePaths: [],
+      unchangedPaths: [],
+    });
+    await storage.applyBatch(VAULT_A, upsertBatch(1, [note("B.md"), note("A.md")]));
+    expect(await storage.planReconciliation(VAULT_A, 2, descriptor(), [])).toMatchObject({
+      uploadPaths: [],
+      deletePaths: ["A.md", "B.md"],
+      unchangedPaths: [],
+    });
+  });
+
+  it("plans a full replacement for an incompatible descriptor", async () => {
+    await storage.applyBatch(VAULT_A, upsertBatch(1, [note("A.md")]));
+    const incoming = note("B.md");
+    const plan = await storage.planReconciliation(VAULT_A, 2, descriptor({ model: "new", embeddingSpaceId: "new" }), [{
+      path: incoming.path,
+      contentHash: incoming.contentHash,
+      chunks: incoming.chunks.map((chunk) => ({ chunkId: chunk.chunkId, contentHash: chunk.contentHash })),
+    }]);
+    expect(plan).toMatchObject({ replaceVault: true, uploadPaths: ["B.md"], deletePaths: ["A.md"] });
+  });
+
+  it("normalizes storage failures without exposing raw database errors", async () => {
+    const left = note("Left.md");
+    const right = note("Right.md");
+    left.chunks[0]!.chunkId = "collision";
+    right.chunks[0]!.chunkId = "collision";
+    const bad: SyncBatchRequest = {
+      protocolVersion: PROTOCOL_VERSION,
+      generation: 1,
+      descriptor: descriptor(),
+      operations: [{ type: "UPSERT", note: left }, { type: "UPSERT", note: right }],
+    };
+    await expect(storage.applyBatch(VAULT_A, bad)).rejects.toBeInstanceOf(ProtocolError);
+    await expect(storage.applyBatch(VAULT_A, bad)).rejects.not.toThrow(/UNIQUE|SQLITE/iu);
+  });
+});

--- a/companion/tsconfig.json
+++ b/companion/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2023"],
+    "types": ["node"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "sourceMap": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "tests"]
+}

--- a/companion/tsconfig.test.json
+++ b/companion/tsconfig.test.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": { "noEmit": true, "rootDir": "." },
+  "include": ["src/**/*.ts", "tests/**/*.ts"],
+  "exclude": []
+}

--- a/companionSync/client.test.ts
+++ b/companionSync/client.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { RequestUrlParam, RequestUrlResponse } from "obsidian";
+
+const obsidianMocks = vi.hoisted(() => ({
+  requestUrl: vi.fn<(request: RequestUrlParam) => Promise<RequestUrlResponse>>(),
+}));
+
+vi.mock("obsidian", () => ({ requestUrl: obsidianMocks.requestUrl }));
+
+import { CompanionClient, CompanionClientError } from "./client";
+import type { CompanionSettings } from "./types";
+
+const settings: CompanionSettings = {
+  enabled: true,
+  endpoint: "http://127.0.0.1:27124",
+  token: "companion-secret",
+  timeoutMs: 500,
+  vaultId: "11111111-1111-4111-8111-111111111111",
+};
+
+function response(status: number, body: unknown): RequestUrlResponse {
+  const text = JSON.stringify(body);
+  return {
+    status,
+    headers: {},
+    text,
+    json: body,
+    arrayBuffer: new TextEncoder().encode(text).buffer,
+  };
+}
+
+beforeEach(() => {
+  vi.useRealTimers();
+  vi.stubGlobal("window", { setTimeout, clearTimeout });
+  obsidianMocks.requestUrl.mockReset();
+});
+
+describe("CompanionClient", () => {
+  it("sends one authenticated versioned request", async () => {
+    obsidianMocks.requestUrl.mockResolvedValue(response(200, { status: "ok", protocolVersion: 1, vaultCount: 0 }));
+    await new CompanionClient(settings).status();
+    expect(obsidianMocks.requestUrl).toHaveBeenCalledWith(expect.objectContaining({
+      url: "http://127.0.0.1:27124/v1/status",
+      method: "GET",
+      headers: {
+        Authorization: "Bearer companion-secret",
+        "x-companion-protocol-version": "1",
+      },
+    }));
+  });
+
+  it("maps authentication failure without exposing the token", async () => {
+    const noteContent = "private note body";
+    obsidianMocks.requestUrl.mockResolvedValue(response(401, { error: { code: "AUTH_REQUIRED", message: `${settings.token}: ${noteContent}` } }));
+    const pending = new CompanionClient(settings).status();
+    await expect(pending).rejects.toMatchObject({ code: "AUTH_REQUIRED" });
+    await expect(pending).rejects.not.toThrow(settings.token);
+    await expect(pending).rejects.not.toThrow(noteContent);
+  });
+
+  it("detects incompatible successful responses", async () => {
+    obsidianMocks.requestUrl.mockResolvedValue(response(200, { status: "ok", protocolVersion: 2, vaultCount: 0 }));
+    await expect(new CompanionClient(settings).status()).rejects.toMatchObject({ code: "PROTOCOL_VERSION_MISMATCH" });
+  });
+
+  it("rejects plaintext remote HTTP before making a request", async () => {
+    expect(() => new CompanionClient({ ...settings, endpoint: "http://vault.example.com" })).toThrow(CompanionClientError);
+    expect(obsidianMocks.requestUrl).not.toHaveBeenCalled();
+  });
+
+  it("handles timeout without waiting for the underlying transport", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("window", { setTimeout, clearTimeout });
+    obsidianMocks.requestUrl.mockImplementation(() => new Promise(() => undefined));
+    const pending = new CompanionClient(settings).status();
+    const assertion = expect(pending).rejects.toMatchObject({ code: "TIMEOUT" });
+    await vi.advanceTimersByTimeAsync(500);
+    await assertion;
+  });
+
+  it("handles AbortSignal cancellation", async () => {
+    obsidianMocks.requestUrl.mockImplementation(() => new Promise(() => undefined));
+    const abort = new AbortController();
+    const pending = new CompanionClient(settings).status(abort.signal);
+    abort.abort();
+    await expect(pending).rejects.toMatchObject({ code: "ABORTED" });
+  });
+});

--- a/companionSync/client.ts
+++ b/companionSync/client.ts
@@ -1,0 +1,155 @@
+import { requestUrl } from "obsidian";
+import type { RequestUrlParam, RequestUrlResponse } from "obsidian";
+import {
+  COMPANION_PROTOCOL_HEADER,
+  COMPANION_PROTOCOL_VERSION,
+} from "./types";
+import type {
+  CompanionReconciliationPlan,
+  CompanionServerStatus,
+  CompanionSettings,
+  CompanionSyncBatch,
+  CompanionSyncBatchResult,
+} from "./types";
+import { isLocalCompanionEndpoint } from "./settings";
+
+export type CompanionClientErrorCode =
+  | "CONFIGURATION_ERROR"
+  | "AUTH_REQUIRED"
+  | "PROTOCOL_VERSION_MISMATCH"
+  | "DESCRIPTOR_MISMATCH"
+  | "STALE_GENERATION"
+  | "INVALID_RESPONSE"
+  | "TIMEOUT"
+  | "ABORTED"
+  | "UNREACHABLE"
+  | "SERVER_ERROR";
+
+export class CompanionClientError extends Error {
+  constructor(readonly code: CompanionClientErrorCode, readonly status = 0) {
+    super(`Companion request failed (${code}).`);
+    this.name = code === "TIMEOUT" ? "TimeoutError" : "CompanionClientError";
+  }
+}
+
+export type CompanionRequest = (request: RequestUrlParam | string) => Promise<RequestUrlResponse>;
+
+function endpoint(value: string): string {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new CompanionClientError("CONFIGURATION_ERROR");
+  }
+  if ((url.protocol !== "http:" && url.protocol !== "https:") || url.username || url.password || url.search || url.hash) {
+    throw new CompanionClientError("CONFIGURATION_ERROR");
+  }
+  if (!isLocalCompanionEndpoint(url.toString()) && url.protocol !== "https:") {
+    throw new CompanionClientError("CONFIGURATION_ERROR");
+  }
+  url.pathname = url.pathname.replace(/\/+$/u, "");
+  return url.toString().replace(/\/$/u, "");
+}
+
+function errorCode(status: number, body: unknown): CompanionClientErrorCode {
+  const code = body && typeof body === "object" && "error" in body &&
+    body.error && typeof body.error === "object" && "code" in body.error
+    ? (body.error as { code?: unknown }).code
+    : undefined;
+  if (status === 401) return "AUTH_REQUIRED";
+  if (code === "PROTOCOL_VERSION_MISMATCH") return "PROTOCOL_VERSION_MISMATCH";
+  if (code === "DESCRIPTOR_MISMATCH") return "DESCRIPTOR_MISMATCH";
+  if (code === "STALE_GENERATION") return "STALE_GENERATION";
+  return status >= 500 ? "SERVER_ERROR" : "INVALID_RESPONSE";
+}
+
+export class CompanionClient {
+  private readonly baseUrl: string;
+
+  constructor(
+    private readonly settings: CompanionSettings,
+    private readonly performRequest: CompanionRequest = requestUrl,
+  ) {
+    this.baseUrl = endpoint(settings.endpoint);
+    if (!settings.token.trim() || !Number.isSafeInteger(settings.timeoutMs) || settings.timeoutMs < 500) {
+      throw new CompanionClientError("CONFIGURATION_ERROR");
+    }
+  }
+
+  status(signal?: AbortSignal): Promise<CompanionServerStatus> {
+    return this.request("/v1/status", "GET", undefined, signal);
+  }
+
+  plan(vaultId: string, snapshot: CompanionSnapshotLike, signal?: AbortSignal): Promise<CompanionReconciliationPlan> {
+    return this.request(`/v1/vaults/${encodeURIComponent(vaultId)}/reconcile/plan`, "POST", {
+      protocolVersion: COMPANION_PROTOCOL_VERSION,
+      generation: snapshot.generation,
+      descriptor: snapshot.descriptor,
+      notes: snapshot.notes.map((note) => ({
+        path: note.path,
+        contentHash: note.contentHash,
+        chunks: note.chunks.map((chunk) => ({ chunkId: chunk.chunkId, contentHash: chunk.contentHash })),
+      })),
+    }, signal);
+  }
+
+  applyBatch(vaultId: string, batch: CompanionSyncBatch, signal?: AbortSignal): Promise<CompanionSyncBatchResult> {
+    return this.request(`/v1/vaults/${encodeURIComponent(vaultId)}/sync/batch`, "POST", batch, signal);
+  }
+
+  private async request<T>(path: string, method: string, body?: unknown, signal?: AbortSignal): Promise<T> {
+    if (signal?.aborted) throw new CompanionClientError("ABORTED");
+    let timer = 0;
+    let abortListener: (() => void) | undefined;
+    const timeout = new Promise<never>((_resolve, reject) => {
+      timer = window.setTimeout(() => reject(new CompanionClientError("TIMEOUT")), this.settings.timeoutMs);
+    });
+    const aborted = new Promise<never>((_resolve, reject) => {
+      abortListener = () => reject(new CompanionClientError("ABORTED"));
+      signal?.addEventListener("abort", abortListener, { once: true });
+    });
+    let response: RequestUrlResponse;
+    try {
+      const request = this.performRequest({
+        url: `${this.baseUrl}${path}`,
+        method,
+        contentType: "application/json",
+        headers: {
+          Authorization: `Bearer ${this.settings.token}`,
+          [COMPANION_PROTOCOL_HEADER]: String(COMPANION_PROTOCOL_VERSION),
+        },
+        ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+        throw: false,
+      }).catch(() => {
+        throw new CompanionClientError("UNREACHABLE");
+      });
+      response = await Promise.race([request, timeout, aborted]);
+    } finally {
+      window.clearTimeout(timer);
+      if (abortListener) signal?.removeEventListener("abort", abortListener);
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(response.text) as unknown;
+    } catch {
+      throw new CompanionClientError("INVALID_RESPONSE", response.status);
+    }
+    if (response.status < 200 || response.status >= 300) {
+      throw new CompanionClientError(errorCode(response.status, parsed), response.status);
+    }
+    if (!parsed || typeof parsed !== "object" || (parsed as { protocolVersion?: unknown }).protocolVersion !== COMPANION_PROTOCOL_VERSION) {
+      throw new CompanionClientError("PROTOCOL_VERSION_MISMATCH", response.status);
+    }
+    return parsed as T;
+  }
+}
+
+interface CompanionSnapshotLike {
+  generation: number;
+  descriptor: CompanionSyncBatch["descriptor"];
+  notes: Array<{
+    path: string;
+    contentHash: string;
+    chunks: Array<{ chunkId: string; contentHash: string }>;
+  }>;
+}

--- a/companionSync/index.ts
+++ b/companionSync/index.ts
@@ -1,0 +1,4 @@
+export * from "./client";
+export * from "./service";
+export * from "./settings";
+export * from "./types";

--- a/companionSync/service.test.ts
+++ b/companionSync/service.test.ts
@@ -76,6 +76,17 @@ function fakeClient(): CompanionClientPort {
   };
 }
 
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve(value: T): void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
 beforeEach(() => vi.stubGlobal("window", { setTimeout, clearTimeout }));
 
 describe("CompanionSyncService", () => {
@@ -144,6 +155,145 @@ describe("CompanionSyncService", () => {
     service.enqueueIncremental(settings, { snapshot: state, deletePaths: [] });
     await service.drain();
     expect(vi.mocked(client.applyBatch).mock.calls.map((call) => call[1].operations.length)).toEqual([50, 50, 1]);
+  });
+
+  it("drops queued incremental work after configuration invalidation", async () => {
+    const client = fakeClient();
+    const firstStarted = deferred<void>();
+    const releaseFirst = deferred<CompanionSyncBatchResult>();
+    vi.mocked(client.applyBatch)
+      .mockImplementationOnce(() => {
+        firstStarted.resolve();
+        return releaseFirst.promise;
+      })
+      .mockResolvedValue(batchResult());
+    const clientFactory = vi.fn(() => client);
+    const service = new CompanionSyncService({ clientFactory });
+    service.enqueueIncremental(settings, { snapshot: snapshot(1), deletePaths: [] });
+    await firstStarted.promise;
+    service.enqueueIncremental(settings, { snapshot: snapshot(2), deletePaths: [] });
+
+    service.invalidateConfiguration();
+    releaseFirst.resolve(batchResult());
+    await service.drain();
+
+    expect(client.applyBatch).toHaveBeenCalledOnce();
+    expect(clientFactory).toHaveBeenCalledOnce();
+    expect(service.getStatus(true)).toEqual({ kind: "idle" });
+  });
+
+  it("does not apply a reconciliation plan resolved after invalidation", async () => {
+    const client = fakeClient();
+    const planStarted = deferred<void>();
+    const releasePlan = deferred<CompanionReconciliationPlan>();
+    vi.mocked(client.plan).mockImplementation(() => {
+      planStarted.resolve();
+      return releasePlan.promise;
+    });
+    const service = new CompanionSyncService({ clientFactory: () => client });
+    const pending = service.reconcile(settings, snapshot());
+    await planStarted.promise;
+
+    service.invalidateConfiguration();
+    releasePlan.resolve(plan({ uploadPaths: ["A.md"], unchangedPaths: ["B.md"] }));
+    await pending;
+
+    expect(client.applyBatch).not.toHaveBeenCalled();
+    expect(service.getStatus(true)).toEqual({ kind: "idle" });
+  });
+
+  it("does not send another batch after configuration invalidation", async () => {
+    const client = fakeClient();
+    const firstStarted = deferred<void>();
+    const releaseFirst = deferred<CompanionSyncBatchResult>();
+    vi.mocked(client.applyBatch)
+      .mockImplementationOnce(() => {
+        firstStarted.resolve();
+        return releaseFirst.promise;
+      })
+      .mockResolvedValue(batchResult());
+    const state = snapshot(5);
+    state.notes = Array.from({ length: 101 }, (_value, index) => ({
+      ...state.notes[0],
+      path: `Batch-${String(index).padStart(3, "0")}.md`,
+      chunks: [],
+    }));
+    const service = new CompanionSyncService({ clientFactory: () => client });
+    service.enqueueIncremental(settings, { snapshot: state, deletePaths: [] });
+    await firstStarted.promise;
+
+    service.invalidateConfiguration();
+    releaseFirst.resolve(batchResult());
+    await service.drain();
+
+    expect(client.applyBatch).toHaveBeenCalledOnce();
+  });
+
+  it("does not retry after configuration is invalidated during backoff", async () => {
+    const client = fakeClient();
+    vi.mocked(client.applyBatch).mockRejectedValue(new CompanionClientError("UNREACHABLE"));
+    const delayStarted = deferred<void>();
+    const releaseDelay = deferred<void>();
+    const service = new CompanionSyncService({
+      clientFactory: () => client,
+      delay: async () => {
+        delayStarted.resolve();
+        await releaseDelay.promise;
+      },
+    });
+    service.enqueueIncremental(settings, { snapshot: snapshot(), deletePaths: [] });
+    await delayStarted.promise;
+
+    service.invalidateConfiguration();
+    releaseDelay.resolve();
+    await service.drain();
+
+    expect(client.applyBatch).toHaveBeenCalledOnce();
+    expect(service.getStatus(true)).toEqual({ kind: "idle" });
+  });
+
+  it("uses new connection settings for work requested after invalidation", async () => {
+    const client = fakeClient();
+    const clientFactory = vi.fn(() => client);
+    const service = new CompanionSyncService({ clientFactory });
+    const newSettings: CompanionSettings = {
+      ...settings,
+      endpoint: "https://new-vault.example.com",
+      token: "new-secret",
+      timeoutMs: 2500,
+    };
+
+    service.invalidateConfiguration();
+    await service.reconcile(newSettings, snapshot(6));
+
+    expect(clientFactory).toHaveBeenCalledOnce();
+    expect(clientFactory).toHaveBeenCalledWith(newSettings);
+    expect(service.getStatus(true).kind).toBe("ready");
+  });
+
+  it("reports disabled without a server error when in-flight work becomes obsolete", async () => {
+    const client = fakeClient();
+    const requestStarted = deferred<void>();
+    const releaseRequest = deferred<void>();
+    vi.mocked(client.applyBatch).mockImplementation(async () => {
+      requestStarted.resolve();
+      await releaseRequest.promise;
+      throw new CompanionClientError("UNREACHABLE");
+    });
+    const service = new CompanionSyncService({ clientFactory: () => client });
+    service.enqueueIncremental(settings, { snapshot: snapshot(), deletePaths: [] });
+    await requestStarted.promise;
+
+    service.invalidateConfiguration();
+    const disabledSettings = { ...settings, enabled: false };
+    service.enqueueIncremental(disabledSettings, { snapshot: snapshot(3), deletePaths: [] });
+    expect(service.getStatus(false)).toEqual({ kind: "disabled" });
+    releaseRequest.resolve();
+    await service.drain();
+
+    expect(client.applyBatch).toHaveBeenCalledOnce();
+    expect(service.getStatus(false)).toEqual({ kind: "disabled" });
+    expect(service.getStatus(true)).toEqual({ kind: "idle" });
   });
 
   it("uses bounded retry and then reports an offline error", async () => {

--- a/companionSync/service.test.ts
+++ b/companionSync/service.test.ts
@@ -1,0 +1,204 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("obsidian", () => ({ requestUrl: vi.fn() }));
+
+import { CompanionClientError } from "./client";
+import { CompanionSyncService } from "./service";
+import type { CompanionClientPort } from "./service";
+import type {
+  CompanionReconciliationPlan,
+  CompanionSettings,
+  CompanionSnapshot,
+  CompanionSyncBatchResult,
+} from "./types";
+
+const settings: CompanionSettings = {
+  enabled: true,
+  endpoint: "https://vault.example.com",
+  token: "secret",
+  timeoutMs: 1000,
+  vaultId: "11111111-1111-4111-8111-111111111111",
+};
+
+function snapshot(generation = 2): CompanionSnapshot {
+  const makeNote = (path: string) => ({
+    path,
+    content: `# ${path}`,
+    contentHash: `note-${path}`,
+    metadata: {},
+    chunks: [{
+      chunkId: `chunk-${path}`,
+      notePath: path,
+      ordinal: 0,
+      headingPath: [path],
+      text: path,
+      contentHash: `hash-${path}`,
+      source: { startOffset: 0, endOffset: path.length, startLine: 0, endLine: 0 },
+      embedding: [1, 0, 0],
+    }],
+  });
+  return {
+    generation,
+    descriptor: {
+      providerId: "openai-compatible",
+      model: "embed",
+      baseUrl: "https://embed.example/v1",
+      dimensions: 3,
+      embeddingSpaceId: "space",
+      normalized: true,
+    },
+    notes: [makeNote("A.md"), makeNote("B.md")],
+  };
+}
+
+function plan(overrides: Partial<CompanionReconciliationPlan> = {}): CompanionReconciliationPlan {
+  return {
+    protocolVersion: 1,
+    generation: 2,
+    serverGeneration: 1,
+    replaceVault: false,
+    uploadPaths: [],
+    deletePaths: [],
+    unchangedPaths: ["A.md", "B.md"],
+    ...overrides,
+  };
+}
+
+function batchResult(): CompanionSyncBatchResult {
+  return { protocolVersion: 1, generation: 2, applied: true, stale: false, operationsApplied: 1 };
+}
+
+function fakeClient(): CompanionClientPort {
+  return {
+    status: vi.fn(async () => ({ status: "ok" as const, protocolVersion: 1 as const, vaultCount: 0 })),
+    plan: vi.fn(async () => plan()),
+    applyBatch: vi.fn(async () => batchResult()),
+  };
+}
+
+beforeEach(() => vi.stubGlobal("window", { setTimeout, clearTimeout }));
+
+describe("CompanionSyncService", () => {
+  it("uploads only paths requested by reconciliation and deletes stale paths", async () => {
+    const client = fakeClient();
+    vi.mocked(client.plan).mockResolvedValue(plan({ uploadPaths: ["B.md"], deletePaths: ["Stale.md"], unchangedPaths: ["A.md"] }));
+    const service = new CompanionSyncService({ clientFactory: () => client });
+    await service.reconcile(settings, snapshot());
+    const sent = vi.mocked(client.applyBatch).mock.calls[0];
+    expect(sent?.[0]).toBe(settings.vaultId);
+    expect(sent?.[1].operations[0]).toEqual({ type: "DELETE", path: "Stale.md" });
+    expect(sent?.[1].operations[1]?.type).toBe("UPSERT");
+    expect(sent?.[1].operations[1]?.type === "UPSERT" ? sent[1].operations[1].note.path : "").toBe("B.md");
+  });
+
+  it("makes a converged reconciliation a no-op", async () => {
+    const client = fakeClient();
+    const service = new CompanionSyncService({ clientFactory: () => client });
+    await service.reconcile(settings, snapshot());
+    expect(client.applyBatch).not.toHaveBeenCalled();
+  });
+
+  it("sends an explicit atomic RENAME with the new frozen note", async () => {
+    const client = fakeClient();
+    const service = new CompanionSyncService({ clientFactory: () => client });
+    const state = snapshot();
+    state.notes = state.notes.filter((item) => item.path === "B.md");
+    service.enqueueIncremental(settings, {
+      snapshot: state,
+      deletePaths: ["A.md"],
+      renames: [{ oldPath: "A.md", newPath: "B.md" }],
+    });
+    await service.drain();
+    const sent = vi.mocked(client.applyBatch).mock.calls[0]?.[1].operations[0];
+    expect(sent?.type).toBe("RENAME");
+    expect(sent?.type === "RENAME" ? { oldPath: sent.oldPath, newPath: sent.note.path } : null).toEqual({
+      oldPath: "A.md",
+      newPath: "B.md",
+    });
+  });
+
+  it("maps create, modify, and delete changes to deterministic incremental operations", async () => {
+    const client = fakeClient();
+    const service = new CompanionSyncService({ clientFactory: () => client });
+    service.enqueueIncremental(settings, {
+      snapshot: snapshot(3),
+      deletePaths: ["Removed.md"],
+    });
+    await service.drain();
+    expect(vi.mocked(client.applyBatch).mock.calls[0]?.[1].operations.map((operation) => {
+      if (operation.type === "UPSERT") return `${operation.type}:${operation.note.path}`;
+      if (operation.type === "DELETE") return `${operation.type}:${operation.path}`;
+      return `${operation.type}:${operation.oldPath}->${operation.note.path}`;
+    })).toEqual(["DELETE:Removed.md", "UPSERT:A.md", "UPSERT:B.md"]);
+  });
+
+  it("splits large incremental changes into bounded batches", async () => {
+    const client = fakeClient();
+    const state = snapshot(4);
+    state.notes = Array.from({ length: 101 }, (_value, index) => ({
+      ...state.notes[0],
+      path: `Note-${String(index).padStart(3, "0")}.md`,
+      chunks: [],
+    }));
+    const service = new CompanionSyncService({ clientFactory: () => client });
+    service.enqueueIncremental(settings, { snapshot: state, deletePaths: [] });
+    await service.drain();
+    expect(vi.mocked(client.applyBatch).mock.calls.map((call) => call[1].operations.length)).toEqual([50, 50, 1]);
+  });
+
+  it("uses bounded retry and then reports an offline error", async () => {
+    const client = fakeClient();
+    vi.mocked(client.applyBatch).mockRejectedValue(new CompanionClientError("UNREACHABLE"));
+    const delay = vi.fn(async () => undefined);
+    const service = new CompanionSyncService({ clientFactory: () => client, delay });
+    service.enqueueIncremental(settings, { snapshot: snapshot(), deletePaths: [] });
+    await service.drain();
+    expect(client.applyBatch).toHaveBeenCalledTimes(2);
+    expect(delay).toHaveBeenCalledOnce();
+    expect(service.getStatus(true)).toMatchObject({ kind: "error", code: "UNREACHABLE" });
+  });
+
+  it("repairs a lost offline incremental change during later reconciliation", async () => {
+    const client = fakeClient();
+    vi.mocked(client.applyBatch).mockRejectedValue(new CompanionClientError("UNREACHABLE"));
+    const service = new CompanionSyncService({
+      clientFactory: () => client,
+      delay: async () => undefined,
+    });
+    service.enqueueIncremental(settings, { snapshot: snapshot(2), deletePaths: [] });
+    await service.drain();
+    vi.mocked(client.applyBatch).mockReset();
+    vi.mocked(client.applyBatch).mockResolvedValue(batchResult());
+    vi.mocked(client.plan).mockResolvedValue(plan({
+      generation: 3,
+      uploadPaths: ["B.md"],
+      deletePaths: ["Stale.md"],
+      unchangedPaths: ["A.md"],
+    }));
+
+    await service.reconcile(settings, snapshot(3));
+
+    expect(vi.mocked(client.applyBatch).mock.calls[0]?.[1].operations).toMatchObject([
+      { type: "DELETE", path: "Stale.md" },
+      { type: "UPSERT", note: { path: "B.md" } },
+    ]);
+    expect(service.getStatus(true).kind).toBe("ready");
+  });
+
+  it("serializes a newer generation after a slow frozen generation", async () => {
+    const client = fakeClient();
+    let release = (): void => undefined;
+    const gate = new Promise<void>((resolve) => { release = resolve; });
+    vi.mocked(client.applyBatch)
+      .mockImplementationOnce(async () => { await gate; return batchResult(); })
+      .mockResolvedValue(batchResult());
+    const service = new CompanionSyncService({ clientFactory: () => client });
+    service.enqueueIncremental(settings, { snapshot: snapshot(1), deletePaths: [] });
+    service.enqueueIncremental(settings, { snapshot: snapshot(2), deletePaths: [] });
+    await Promise.resolve();
+    expect(client.applyBatch).toHaveBeenCalledTimes(1);
+    release();
+    await service.drain();
+    expect(vi.mocked(client.applyBatch).mock.calls.map((call) => call[1].generation)).toEqual([1, 2]);
+  });
+});

--- a/companionSync/service.ts
+++ b/companionSync/service.ts
@@ -11,6 +11,7 @@ import { COMPANION_PROTOCOL_VERSION } from "./types";
 
 const BATCH_SIZE = 50;
 const MAX_ATTEMPTS = 2;
+const CONFIGURATION_INVALIDATED = Symbol("configuration-invalidated");
 
 export interface CompanionSyncServiceOptions {
   clientFactory?: (settings: CompanionSettings) => CompanionClientPort;
@@ -25,6 +26,7 @@ export interface CompanionClientPort {
 
 export interface CompanionSyncPort {
   getStatus: (enabled: boolean) => CompanionConnectionStatus;
+  invalidateConfiguration: () => void;
   testConnection: (settings: CompanionSettings, signal?: AbortSignal) => Promise<void>;
   reconcile: (settings: CompanionSettings, snapshot: CompanionSnapshot, signal?: AbortSignal) => Promise<void>;
   enqueueIncremental: (settings: CompanionSettings, change: CompanionIncrementalChange) => void;
@@ -36,6 +38,7 @@ export class CompanionSyncService implements CompanionSyncPort {
   private readonly delay: (milliseconds: number) => Promise<void>;
   private tail: Promise<void> = Promise.resolve();
   private status: CompanionConnectionStatus = { kind: "idle" };
+  private configurationEpoch = 0;
   private disposed = false;
 
   constructor(options: CompanionSyncServiceOptions = {}) {
@@ -47,25 +50,36 @@ export class CompanionSyncService implements CompanionSyncPort {
     return enabled ? { ...this.status } : { kind: "disabled" };
   }
 
+  invalidateConfiguration(): void {
+    this.configurationEpoch++;
+    this.status = { kind: "idle" };
+  }
+
   async testConnection(settings: CompanionSettings, signal?: AbortSignal): Promise<void> {
+    const epoch = this.configurationEpoch;
     this.status = { kind: "syncing" };
     try {
       await this.clientFactory(settings).status(signal);
+      if (!this.isCurrent(epoch)) return;
       this.status = { kind: "ready", lastSuccessAt: Date.now() };
     } catch (error) {
+      if (!this.isCurrent(epoch)) return;
       this.recordError(error);
       throw error;
     }
   }
 
   async reconcile(settings: CompanionSettings, snapshot: CompanionSnapshot, signal?: AbortSignal): Promise<void> {
+    if (this.disposed || !settings.enabled) return;
+    const epoch = this.configurationEpoch;
     const frozenSettings = { ...settings };
     const pending = this.tail.then(async () => {
-      if (this.disposed) return;
+      if (!this.isCurrent(epoch)) return;
       this.status = { kind: "syncing" };
       try {
         const client = this.clientFactory(frozenSettings);
-        const plan = await this.withRetry(() => client.plan(frozenSettings.vaultId, snapshot, signal));
+        const plan = await this.withRetry(epoch, () => client.plan(frozenSettings.vaultId, snapshot, signal));
+        if (plan === CONFIGURATION_INVALIDATED || !this.isCurrent(epoch)) return;
         const notes = new Map(snapshot.notes.map((note) => [note.path, note]));
         const operations: CompanionSyncOperation[] = [];
         if (!plan.replaceVault) {
@@ -75,9 +89,19 @@ export class CompanionSyncService implements CompanionSyncPort {
           const note = notes.get(path);
           if (note) operations.push({ type: "UPSERT", note });
         }
-        await this.applyOperations(client, frozenSettings, snapshot, operations, plan.replaceVault, signal);
+        const applied = await this.applyOperations(
+          epoch,
+          client,
+          frozenSettings,
+          snapshot,
+          operations,
+          plan.replaceVault,
+          signal,
+        );
+        if (!applied || !this.isCurrent(epoch)) return;
         this.status = { kind: "ready", lastSuccessAt: Date.now() };
       } catch (error) {
+        if (!this.isCurrent(epoch)) return;
         this.recordError(error);
         throw error;
       }
@@ -88,9 +112,10 @@ export class CompanionSyncService implements CompanionSyncPort {
 
   enqueueIncremental(settings: CompanionSettings, change: CompanionIncrementalChange): void {
     if (this.disposed || !settings.enabled) return;
+    const epoch = this.configurationEpoch;
     const frozenSettings = { ...settings };
     this.tail = this.tail.then(async () => {
-      if (this.disposed) return;
+      if (!this.isCurrent(epoch)) return;
       this.status = { kind: "syncing" };
       try {
         const client = this.clientFactory(frozenSettings);
@@ -111,9 +136,18 @@ export class CompanionSyncService implements CompanionSyncPort {
         for (const note of [...change.snapshot.notes].sort((left, right) => left.path.localeCompare(right.path))) {
           if (!consumedUpserts.has(note.path)) operations.push({ type: "UPSERT", note });
         }
-        await this.applyOperations(client, frozenSettings, change.snapshot, operations, false);
+        const applied = await this.applyOperations(
+          epoch,
+          client,
+          frozenSettings,
+          change.snapshot,
+          operations,
+          false,
+        );
+        if (!applied || !this.isCurrent(epoch)) return;
         this.status = { kind: "ready", lastSuccessAt: Date.now() };
       } catch (error) {
+        if (!this.isCurrent(epoch)) return;
         this.recordError(error);
       }
     });
@@ -125,23 +159,27 @@ export class CompanionSyncService implements CompanionSyncPort {
 
   async dispose(): Promise<void> {
     this.disposed = true;
+    this.configurationEpoch++;
     await this.tail;
   }
 
   private async applyOperations(
+    epoch: number,
     client: CompanionClientPort,
     settings: CompanionSettings,
     snapshot: CompanionSnapshot,
     operations: readonly CompanionSyncOperation[],
     replaceVault: boolean,
     signal?: AbortSignal,
-  ): Promise<void> {
-    if (operations.length === 0 && !replaceVault) return;
+  ): Promise<boolean> {
+    if (!this.isCurrent(epoch)) return false;
+    if (operations.length === 0 && !replaceVault) return true;
     const batches = operations.length === 0 ? [[]] : Array.from(
       { length: Math.ceil(operations.length / BATCH_SIZE) },
       (_value, index) => operations.slice(index * BATCH_SIZE, (index + 1) * BATCH_SIZE),
     );
     for (let index = 0; index < batches.length; index++) {
+      if (!this.isCurrent(epoch)) return false;
       const batch: CompanionSyncBatch = {
         protocolVersion: COMPANION_PROTOCOL_VERSION,
         generation: snapshot.generation,
@@ -149,24 +187,40 @@ export class CompanionSyncService implements CompanionSyncPort {
         operations: [...(batches[index] ?? [])],
       };
       if (replaceVault && index === 0) batch.replaceVault = true;
-      await this.withRetry(() => client.applyBatch(settings.vaultId, batch, signal));
+      const result = await this.withRetry(
+        epoch,
+        () => client.applyBatch(settings.vaultId, batch, signal),
+      );
+      if (result === CONFIGURATION_INVALIDATED) return false;
     }
+    return this.isCurrent(epoch);
   }
 
-  private async withRetry<T>(operation: () => Promise<T>): Promise<T> {
+  private async withRetry<T>(
+    epoch: number,
+    operation: () => Promise<T>,
+  ): Promise<T | typeof CONFIGURATION_INVALIDATED> {
     let lastError: unknown;
     for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+      if (!this.isCurrent(epoch)) return CONFIGURATION_INVALIDATED;
       try {
-        return await operation();
+        const result = await operation();
+        return this.isCurrent(epoch) ? result : CONFIGURATION_INVALIDATED;
       } catch (error) {
+        if (!this.isCurrent(epoch)) return CONFIGURATION_INVALIDATED;
         lastError = error;
         const retryable = error instanceof CompanionClientError &&
           (error.code === "TIMEOUT" || error.code === "UNREACHABLE" || error.code === "SERVER_ERROR");
         if (!retryable || attempt + 1 >= MAX_ATTEMPTS) throw error;
         await this.delay(250 * (attempt + 1));
+        if (!this.isCurrent(epoch)) return CONFIGURATION_INVALIDATED;
       }
     }
     throw lastError;
+  }
+
+  private isCurrent(epoch: number): boolean {
+    return !this.disposed && epoch === this.configurationEpoch;
   }
 
   private recordError(error: unknown): void {

--- a/companionSync/service.ts
+++ b/companionSync/service.ts
@@ -1,0 +1,178 @@
+import { CompanionClient, CompanionClientError } from "./client";
+import type {
+  CompanionConnectionStatus,
+  CompanionIncrementalChange,
+  CompanionSettings,
+  CompanionSnapshot,
+  CompanionSyncBatch,
+  CompanionSyncOperation,
+} from "./types";
+import { COMPANION_PROTOCOL_VERSION } from "./types";
+
+const BATCH_SIZE = 50;
+const MAX_ATTEMPTS = 2;
+
+export interface CompanionSyncServiceOptions {
+  clientFactory?: (settings: CompanionSettings) => CompanionClientPort;
+  delay?: (milliseconds: number) => Promise<void>;
+}
+
+export interface CompanionClientPort {
+  status: (signal?: AbortSignal) => ReturnType<CompanionClient["status"]>;
+  plan: (vaultId: string, snapshot: CompanionSnapshot, signal?: AbortSignal) => ReturnType<CompanionClient["plan"]>;
+  applyBatch: (vaultId: string, batch: CompanionSyncBatch, signal?: AbortSignal) => ReturnType<CompanionClient["applyBatch"]>;
+}
+
+export interface CompanionSyncPort {
+  getStatus: (enabled: boolean) => CompanionConnectionStatus;
+  testConnection: (settings: CompanionSettings, signal?: AbortSignal) => Promise<void>;
+  reconcile: (settings: CompanionSettings, snapshot: CompanionSnapshot, signal?: AbortSignal) => Promise<void>;
+  enqueueIncremental: (settings: CompanionSettings, change: CompanionIncrementalChange) => void;
+  dispose: () => Promise<void>;
+}
+
+export class CompanionSyncService implements CompanionSyncPort {
+  private readonly clientFactory: (settings: CompanionSettings) => CompanionClientPort;
+  private readonly delay: (milliseconds: number) => Promise<void>;
+  private tail: Promise<void> = Promise.resolve();
+  private status: CompanionConnectionStatus = { kind: "idle" };
+  private disposed = false;
+
+  constructor(options: CompanionSyncServiceOptions = {}) {
+    this.clientFactory = options.clientFactory ?? ((settings) => new CompanionClient(settings));
+    this.delay = options.delay ?? ((milliseconds) => new Promise((resolve) => window.setTimeout(resolve, milliseconds)));
+  }
+
+  getStatus(enabled: boolean): CompanionConnectionStatus {
+    return enabled ? { ...this.status } : { kind: "disabled" };
+  }
+
+  async testConnection(settings: CompanionSettings, signal?: AbortSignal): Promise<void> {
+    this.status = { kind: "syncing" };
+    try {
+      await this.clientFactory(settings).status(signal);
+      this.status = { kind: "ready", lastSuccessAt: Date.now() };
+    } catch (error) {
+      this.recordError(error);
+      throw error;
+    }
+  }
+
+  async reconcile(settings: CompanionSettings, snapshot: CompanionSnapshot, signal?: AbortSignal): Promise<void> {
+    const frozenSettings = { ...settings };
+    const pending = this.tail.then(async () => {
+      if (this.disposed) return;
+      this.status = { kind: "syncing" };
+      try {
+        const client = this.clientFactory(frozenSettings);
+        const plan = await this.withRetry(() => client.plan(frozenSettings.vaultId, snapshot, signal));
+        const notes = new Map(snapshot.notes.map((note) => [note.path, note]));
+        const operations: CompanionSyncOperation[] = [];
+        if (!plan.replaceVault) {
+          for (const path of plan.deletePaths) operations.push({ type: "DELETE", path });
+        }
+        for (const path of plan.uploadPaths) {
+          const note = notes.get(path);
+          if (note) operations.push({ type: "UPSERT", note });
+        }
+        await this.applyOperations(client, frozenSettings, snapshot, operations, plan.replaceVault, signal);
+        this.status = { kind: "ready", lastSuccessAt: Date.now() };
+      } catch (error) {
+        this.recordError(error);
+        throw error;
+      }
+    });
+    this.tail = pending.catch(() => undefined);
+    return pending;
+  }
+
+  enqueueIncremental(settings: CompanionSettings, change: CompanionIncrementalChange): void {
+    if (this.disposed || !settings.enabled) return;
+    const frozenSettings = { ...settings };
+    this.tail = this.tail.then(async () => {
+      if (this.disposed) return;
+      this.status = { kind: "syncing" };
+      try {
+        const client = this.clientFactory(frozenSettings);
+        const notes = new Map(change.snapshot.notes.map((note) => [note.path, note]));
+        const consumedDeletes = new Set<string>();
+        const consumedUpserts = new Set<string>();
+        const operations: CompanionSyncOperation[] = [];
+        for (const rename of change.renames ?? []) {
+          const renamed = notes.get(rename.newPath);
+          if (!renamed || !change.deletePaths.includes(rename.oldPath)) continue;
+          operations.push({ type: "RENAME", oldPath: rename.oldPath, note: renamed });
+          consumedDeletes.add(rename.oldPath);
+          consumedUpserts.add(rename.newPath);
+        }
+        for (const path of [...change.deletePaths].sort()) {
+          if (!consumedDeletes.has(path)) operations.push({ type: "DELETE", path });
+        }
+        for (const note of [...change.snapshot.notes].sort((left, right) => left.path.localeCompare(right.path))) {
+          if (!consumedUpserts.has(note.path)) operations.push({ type: "UPSERT", note });
+        }
+        await this.applyOperations(client, frozenSettings, change.snapshot, operations, false);
+        this.status = { kind: "ready", lastSuccessAt: Date.now() };
+      } catch (error) {
+        this.recordError(error);
+      }
+    });
+  }
+
+  async drain(): Promise<void> {
+    await this.tail;
+  }
+
+  async dispose(): Promise<void> {
+    this.disposed = true;
+    await this.tail;
+  }
+
+  private async applyOperations(
+    client: CompanionClientPort,
+    settings: CompanionSettings,
+    snapshot: CompanionSnapshot,
+    operations: readonly CompanionSyncOperation[],
+    replaceVault: boolean,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    if (operations.length === 0 && !replaceVault) return;
+    const batches = operations.length === 0 ? [[]] : Array.from(
+      { length: Math.ceil(operations.length / BATCH_SIZE) },
+      (_value, index) => operations.slice(index * BATCH_SIZE, (index + 1) * BATCH_SIZE),
+    );
+    for (let index = 0; index < batches.length; index++) {
+      const batch: CompanionSyncBatch = {
+        protocolVersion: COMPANION_PROTOCOL_VERSION,
+        generation: snapshot.generation,
+        descriptor: snapshot.descriptor,
+        operations: [...(batches[index] ?? [])],
+      };
+      if (replaceVault && index === 0) batch.replaceVault = true;
+      await this.withRetry(() => client.applyBatch(settings.vaultId, batch, signal));
+    }
+  }
+
+  private async withRetry<T>(operation: () => Promise<T>): Promise<T> {
+    let lastError: unknown;
+    for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+      try {
+        return await operation();
+      } catch (error) {
+        lastError = error;
+        const retryable = error instanceof CompanionClientError &&
+          (error.code === "TIMEOUT" || error.code === "UNREACHABLE" || error.code === "SERVER_ERROR");
+        if (!retryable || attempt + 1 >= MAX_ATTEMPTS) throw error;
+        await this.delay(250 * (attempt + 1));
+      }
+    }
+    throw lastError;
+  }
+
+  private recordError(error: unknown): void {
+    this.status = {
+      kind: "error",
+      code: error instanceof CompanionClientError ? error.code : "SERVER_ERROR",
+    };
+  }
+}

--- a/companionSync/settings.test.ts
+++ b/companionSync/settings.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_COMPANION_SETTINGS,
+  isLocalCompanionEndpoint,
+  mergeCompanionSettings,
+} from "./settings";
+
+const VAULT_ID = "11111111-1111-4111-8111-111111111111";
+
+describe("Companion settings", () => {
+  it("are disabled and local by default", () => {
+    expect(DEFAULT_COMPANION_SETTINGS).toMatchObject({
+      enabled: false,
+      endpoint: "http://127.0.0.1:27124",
+      token: "",
+    });
+  });
+
+  it("generates a vaultId once when none is stored", () => {
+    const generate = vi.fn(() => VAULT_ID);
+    const first = mergeCompanionSettings(null, generate);
+    const second = mergeCompanionSettings(first, generate);
+    expect(first.vaultId).toBe(VAULT_ID);
+    expect(second.vaultId).toBe(VAULT_ID);
+    expect(generate).toHaveBeenCalledOnce();
+  });
+
+  it("persists endpoint and trims accidental token whitespace", () => {
+    const result = mergeCompanionSettings({
+      enabled: true,
+      endpoint: " https://vault.example.com/ ",
+      token: " token-value ",
+      vaultId: VAULT_ID,
+    });
+    expect(result).toMatchObject({
+      enabled: true,
+      endpoint: "https://vault.example.com/",
+      token: "token-value",
+      vaultId: VAULT_ID,
+    });
+  });
+
+  it("distinguishes local endpoints from remote privacy boundaries", () => {
+    expect(isLocalCompanionEndpoint("http://localhost:27124")).toBe(true);
+    expect(isLocalCompanionEndpoint("http://127.0.0.9:27124")).toBe(true);
+    expect(isLocalCompanionEndpoint("https://vault.example.com")).toBe(false);
+  });
+});

--- a/companionSync/settings.ts
+++ b/companionSync/settings.ts
@@ -1,0 +1,48 @@
+import type { CompanionSettings } from "./types";
+
+export const DEFAULT_COMPANION_SETTINGS: Readonly<CompanionSettings> = {
+  enabled: false,
+  endpoint: "http://127.0.0.1:27124",
+  token: "",
+  timeoutMs: 5_000,
+  vaultId: "",
+};
+
+export type StoredCompanionSettings = Partial<CompanionSettings>;
+
+export function isVaultId(value: unknown): value is string {
+  return typeof value === "string" && /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu.test(value);
+}
+
+export function createVaultId(): string {
+  if (typeof window.crypto?.randomUUID !== "function") {
+    throw new Error("A secure UUID generator is required for Companion vault identity.");
+  }
+  return window.crypto.randomUUID();
+}
+
+export function mergeCompanionSettings(
+  stored?: StoredCompanionSettings | null,
+  generateVaultId: () => string = createVaultId,
+): CompanionSettings {
+  return {
+    enabled: stored?.enabled === true,
+    endpoint: typeof stored?.endpoint === "string" && stored.endpoint.trim()
+      ? stored.endpoint.trim()
+      : DEFAULT_COMPANION_SETTINGS.endpoint,
+    token: typeof stored?.token === "string" ? stored.token.trim() : "",
+    timeoutMs: typeof stored?.timeoutMs === "number" && Number.isSafeInteger(stored.timeoutMs) && stored.timeoutMs >= 500 && stored.timeoutMs <= 60_000
+      ? stored.timeoutMs
+      : DEFAULT_COMPANION_SETTINGS.timeoutMs,
+    vaultId: isVaultId(stored?.vaultId) ? stored.vaultId.toLowerCase() : generateVaultId(),
+  };
+}
+
+export function isLocalCompanionEndpoint(value: string): boolean {
+  try {
+    const hostname = new URL(value).hostname.toLowerCase();
+    return hostname === "localhost" || hostname === "[::1]" || /^127(?:\.\d{1,3}){3}$/u.test(hostname);
+  } catch {
+    return false;
+  }
+}

--- a/companionSync/types.ts
+++ b/companionSync/types.ts
@@ -1,0 +1,98 @@
+export const COMPANION_PROTOCOL_VERSION = 1 as const;
+export const COMPANION_PROTOCOL_HEADER = "x-companion-protocol-version";
+
+export interface CompanionSettings {
+  enabled: boolean;
+  endpoint: string;
+  token: string;
+  timeoutMs: number;
+  vaultId: string;
+}
+
+export interface CompanionSemanticDescriptor {
+  providerId: string;
+  model: string;
+  baseUrl: string;
+  dimensions: number;
+  embeddingSpaceId: string;
+  normalized: true;
+}
+
+export interface CompanionChunk {
+  chunkId: string;
+  notePath: string;
+  ordinal: number;
+  headingPath: string[];
+  text: string;
+  contentHash: string;
+  source: {
+    startOffset: number;
+    endOffset: number;
+    startLine: number;
+    endLine: number;
+  };
+  embedding: number[];
+}
+
+export interface CompanionNote {
+  path: string;
+  content: string;
+  contentHash: string;
+  metadata: Record<string, unknown>;
+  chunks: CompanionChunk[];
+}
+
+export interface CompanionSnapshot {
+  generation: number;
+  descriptor: CompanionSemanticDescriptor;
+  notes: CompanionNote[];
+}
+
+export interface CompanionReconciliationPlan {
+  protocolVersion: typeof COMPANION_PROTOCOL_VERSION;
+  generation: number;
+  serverGeneration: number;
+  replaceVault: boolean;
+  uploadPaths: string[];
+  deletePaths: string[];
+  unchangedPaths: string[];
+}
+
+export type CompanionSyncOperation =
+  | { type: "UPSERT"; note: CompanionNote }
+  | { type: "DELETE"; path: string }
+  | { type: "RENAME"; oldPath: string; note: CompanionNote };
+
+export interface CompanionSyncBatch {
+  protocolVersion: typeof COMPANION_PROTOCOL_VERSION;
+  generation: number;
+  descriptor: CompanionSemanticDescriptor;
+  replaceVault?: boolean;
+  operations: CompanionSyncOperation[];
+}
+
+export interface CompanionSyncBatchResult {
+  protocolVersion: typeof COMPANION_PROTOCOL_VERSION;
+  generation: number;
+  applied: boolean;
+  stale: boolean;
+  operationsApplied: number;
+}
+
+export interface CompanionServerStatus {
+  status: "ok";
+  protocolVersion: typeof COMPANION_PROTOCOL_VERSION;
+  vaultCount: number;
+}
+
+export interface CompanionConnectionStatus {
+  kind: "disabled" | "idle" | "syncing" | "ready" | "error";
+  code?: string;
+  lastSuccessAt?: number;
+}
+
+export interface CompanionIncrementalChange {
+  snapshot: CompanionSnapshot;
+  deletePaths: readonly string[];
+  renames?: readonly { oldPath: string; newPath: string }[];
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,6 +5,7 @@ import { defineConfig, globalIgnores } from 'eslint/config';
 export default defineConfig(
   globalIgnores([
     'node_modules',
+    'companion',
     'dist',
     'esbuild.config.mjs',
     'version-bump.mjs',

--- a/main.ts
+++ b/main.ts
@@ -52,6 +52,11 @@ import {
 import { NoteIndexManager } from "./noteIndex";
 import { mergeEmbeddingSettings } from "./embeddings/types";
 import type { StoredEmbeddingSettings } from "./embeddings/types";
+import {
+  isVaultId,
+  mergeCompanionSettings,
+} from "./companionSync";
+import type { StoredCompanionSettings } from "./companionSync";
 import { ObsidianSemanticController } from "./semantic";
 
 type Mode = "simple" | "selection" | "vault";
@@ -202,12 +207,15 @@ export default class AIHubPlugin extends Plugin {
     }
   }
   async loadSettings() {
-    type StoredAIHubSettings = Omit<Partial<AIHubSettings>, "semantic"> & {
+    type StoredAIHubSettings = Omit<Partial<AIHubSettings>, "semantic" | "companion"> & {
       semantic?: StoredEmbeddingSettings;
+      companion?: StoredCompanionSettings;
     };
     const data = (await this.loadData()) as StoredAIHubSettings | null;
+    const needsVaultId = !isVaultId(data?.companion?.vaultId);
     this.settings = Object.assign({}, DEFAULT_SETTINGS, data, {
       semantic: mergeEmbeddingSettings(data?.semantic),
+      companion: mergeCompanionSettings(data?.companion),
     });
 
     // Миграция: если provider не задан — определяем по baseUrl
@@ -220,6 +228,7 @@ export default class AIHubPlugin extends Plugin {
       else if (url.includes("groq.com")) this.settings.provider = "groq";
       else this.settings.provider = "custom";
     }
+    if (needsVaultId) await this.saveData(this.settings);
   }
 
   async saveSettings() {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "node esbuild.config.mjs",
     "build": "node esbuild.config.mjs production",
     "lint": "eslint . --max-warnings 2",
-    "test": "vitest run",
+    "test": "vitest run --exclude 'companion/**'",
     "version": "node version-bump.mjs && git add manifest.json versions.json"
   },
   "keywords": [],

--- a/rag/ragController.integration.test.ts
+++ b/rag/ragController.integration.test.ts
@@ -500,6 +500,7 @@ describe("Ask your Vault controller integration", () => {
     const gate = manualGate();
     const companion: CompanionSyncPort = {
       getStatus: vi.fn(() => ({ kind: "syncing" as const })),
+      invalidateConfiguration: vi.fn(),
       testConnection: vi.fn(async () => undefined),
       reconcile: vi.fn(async () => { await gate.wait; }),
       enqueueIncremental: vi.fn(),

--- a/rag/ragController.integration.test.ts
+++ b/rag/ragController.integration.test.ts
@@ -38,6 +38,7 @@ import type {
 } from "../rag/types";
 import { ObsidianSemanticController } from "../semantic/obsidianSemanticController";
 import type { SemanticRuntime } from "../semantic/types";
+import type { CompanionSyncPort } from "../companionSync";
 
 const INDEX_RESULT = {
   mode: "reconcile" as const,
@@ -83,6 +84,13 @@ function settings(): AIHubSettings {
       openAICompatibleApiKey: "embed-key",
     },
     semanticAutoSyncSuspended: false,
+    companion: {
+      enabled: false,
+      endpoint: "http://127.0.0.1:27124",
+      token: "",
+      timeoutMs: 5000,
+      vaultId: "11111111-1111-4111-8111-111111111111",
+    },
   };
 }
 
@@ -145,6 +153,18 @@ function fakeRuntime(initialContext = ragContext()) {
     buildRagContext: vi.fn(async () => currentContext),
     findSimilarNotes: vi.fn(async () => []),
     findPotentialDuplicates: vi.fn(async () => []),
+    captureCompanionSnapshot: vi.fn(async () => ({
+      generation,
+      descriptor: {
+        providerId: "openai-compatible",
+        model: "embed-model",
+        baseUrl: "https://embed.example/v1",
+        dimensions: 3,
+        embeddingSpaceId: "space",
+        normalized: true as const,
+      },
+      notes: [],
+    })),
     clear: vi.fn(async () => {
       count = 0;
       generation++;
@@ -166,7 +186,7 @@ function fakeRuntime(initialContext = ragContext()) {
   };
 }
 
-function createHarness() {
+function createHarness(companionService?: CompanionSyncPort) {
   const pluginSettings = settings();
   const commands: Command[] = [];
   const notices: string[] = [];
@@ -245,6 +265,7 @@ function createHarness() {
     resetStorage,
     probeIndex,
     autoSyncDebounceMs: 0,
+    companionService,
     notice: (message) => {
       notices.push(message);
       return { hide() {} };
@@ -473,5 +494,31 @@ describe("Ask your Vault controller integration", () => {
 
     expect(sentUser).toContain("old frozen source");
     expect(sentUser).not.toContain("future replacement source");
+  });
+
+  it("keeps Ask your Vault usable while Companion is slow", async () => {
+    const gate = manualGate();
+    const companion: CompanionSyncPort = {
+      getStatus: vi.fn(() => ({ kind: "syncing" as const })),
+      testConnection: vi.fn(async () => undefined),
+      reconcile: vi.fn(async () => { await gate.wait; }),
+      enqueueIncremental: vi.fn(),
+      dispose: vi.fn(async () => undefined),
+    };
+    const harness = createHarness(companion);
+    harness.plugin.settings.companion.enabled = true;
+    harness.plugin.settings.companion.token = "companion-secret";
+    await harness.controller.indexVault();
+    expect(companion.reconcile).toHaveBeenCalledOnce();
+
+    const result = await harness.controller.askVault(
+      "question",
+      {},
+      new AbortController().signal,
+    );
+
+    expect(result.answer).toBe("answer [S1]");
+    expect(result.context.sources[0].text).toBe("old frozen source");
+    gate.release();
   });
 });

--- a/semantic/obsidianSemanticController.test.ts
+++ b/semantic/obsidianSemanticController.test.ts
@@ -25,6 +25,7 @@ vi.mock("obsidian", () => ({
 }));
 
 import type { EmbeddingSettings } from "../embeddings/types";
+import type { CompanionSyncPort } from "../companionSync";
 import { buildEmbeddingSpaceId } from "../indexing";
 import { TFile } from "obsidian";
 import type { Command } from "obsidian";
@@ -256,6 +257,22 @@ describe("ObsidianSemanticController commands and lazy behavior", () => {
     });
   });
   afterEach(() => vi.unstubAllGlobals());
+
+  it("invalidates pending Companion work when connection settings change", () => {
+    const companion: CompanionSyncPort = {
+      getStatus: vi.fn(() => ({ kind: "idle" as const })),
+      invalidateConfiguration: vi.fn(),
+      testConnection: vi.fn(async () => undefined),
+      reconcile: vi.fn(async () => undefined),
+      enqueueIncremental: vi.fn(),
+      dispose: vi.fn(async () => undefined),
+    };
+    const harness = createHarness(semantic(), { companionService: companion });
+
+    harness.controller.notifyCompanionSettingsChanged();
+
+    expect(companion.invalidateConfiguration).toHaveBeenCalledOnce();
+  });
 
   it("registers all semantic commands without runtime or Vault reads", () => {
     const harness = createHarness();

--- a/semantic/obsidianSemanticController.test.ts
+++ b/semantic/obsidianSemanticController.test.ts
@@ -175,6 +175,13 @@ function createHarness(
     settings: {
       semantic: settings,
       semanticAutoSyncSuspended: false,
+      companion: {
+        enabled: false,
+        endpoint: "http://127.0.0.1:27124",
+        token: "",
+        timeoutMs: 5000,
+        vaultId: "11111111-1111-4111-8111-111111111111",
+      },
     },
     addCommand: vi.fn((command: Command) => {
       commands.push(command);

--- a/semantic/obsidianSemanticController.ts
+++ b/semantic/obsidianSemanticController.ts
@@ -73,6 +73,13 @@ import type {
   SemanticStatus,
 } from "./types";
 import { normalizeVectorStoreBasePath } from "../vectorStore";
+import { CompanionClientError, CompanionSyncService } from "../companionSync";
+import type {
+  CompanionConnectionStatus,
+  CompanionIncrementalChange,
+  CompanionSnapshot,
+  CompanionSyncPort,
+} from "../companionSync";
 
 interface SemanticPluginHost {
   app: App;
@@ -119,6 +126,7 @@ export interface SemanticControllerDependencies {
   storeRegistry?: SemanticStoreRegistry;
   streamLanguageModel?: typeof streamOpenRouter;
   autoSyncDebounceMs?: number;
+  companionService?: CompanionSyncPort;
 }
 
 interface RuntimeSlot {
@@ -256,6 +264,8 @@ export class ObsidianSemanticController {
   private readonly streamLanguageModel: typeof streamOpenRouter;
   private readonly ragService: RagService;
   private readonly autoSync: SemanticAutoSync;
+  private readonly companionService: CompanionSyncPort;
+  private readonly pendingCompanionRenames = new Map<string, string>();
   private runtimeSlot: RuntimeSlot | null = null;
   private operationBusy = false;
   private settingsEpoch = 0;
@@ -306,6 +316,7 @@ export class ObsidianSemanticController {
     );
     this.resetStorage = dependencies.resetStorage ?? resetSemanticStorage;
     this.probeIndex = dependencies.probeIndex ?? probeSemanticIndex;
+    this.companionService = dependencies.companionService ?? new CompanionSyncService();
     const automaticSyncSuspended =
       this.plugin.settings.semanticAutoSyncSuspended === true;
     this.autoSyncPolicy = this.plugin.settings.semantic.enabled
@@ -408,6 +419,9 @@ export class ObsidianSemanticController {
       ) {
         this.autoSync.reconcile();
       }
+      if (this.plugin.settings.companion.enabled) {
+        void this.reconcileCompanionQuietly();
+      }
     });
   }
 
@@ -418,16 +432,58 @@ export class ObsidianSemanticController {
       this.autoSync.dispose();
       this.runtimeSlot = null;
     }
-    this.disposePromise = this.indexingQueue.then(
-      () => undefined,
-      () => undefined,
-    );
+    this.disposePromise = Promise.all([
+      this.indexingQueue.then(() => undefined, () => undefined),
+      this.companionService.dispose(),
+    ]).then(() => undefined);
     return this.disposePromise;
   }
 
   getSemanticStatus(): SemanticStatus {
     this.reconcileCachedStatus();
     return { ...this.status };
+  }
+
+  getCompanionStatus(): CompanionConnectionStatus {
+    return this.companionService.getStatus(this.plugin.settings.companion.enabled);
+  }
+
+  notifyCompanionSettingsChanged(): void {
+    // Client configuration is snapshotted per request; editing settings never uploads data.
+  }
+
+  async testCompanionConnection(signal?: AbortSignal): Promise<void> {
+    try {
+      await this.companionService.testConnection(
+        { ...this.plugin.settings.companion },
+        signal,
+      );
+      this.notice(tr("Companion connection successful."));
+    } catch (error) {
+      this.notice(this.companionErrorMessage(error), 8000);
+    }
+  }
+
+  async syncCompanionNow(signal?: AbortSignal): Promise<void> {
+    if (!this.plugin.settings.companion.enabled) {
+      this.notice(tr("Enable Companion before synchronizing Vault data."));
+      return;
+    }
+    try {
+      const snapshot = await this.captureCompanionSnapshot();
+      if (!snapshot) {
+        this.notice(tr("A usable semantic index is required before Companion sync."));
+        return;
+      }
+      await this.companionService.reconcile(
+        { ...this.plugin.settings.companion },
+        snapshot,
+        signal,
+      );
+      this.notice(tr("Companion mirror synchronized."));
+    } catch (error) {
+      this.notice(this.companionErrorMessage(error), 8000);
+    }
   }
 
   notifySettingsChanged(): void {
@@ -634,6 +690,7 @@ export class ObsidianSemanticController {
 
   async indexVault(): Promise<void> {
     if (!this.ensureEnabled() || !this.acquireOperation()) return;
+    let companionSnapshot: CompanionSnapshot | null = null;
     try {
       const fileCount = this.plugin.app.vault.getMarkdownFiles().length;
       const snapshot = safeSettingsSnapshot(this.plugin.settings.semantic);
@@ -673,12 +730,14 @@ export class ObsidianSemanticController {
             this.updateReadyStatus(runtime);
             await this.activateAutomaticSync();
             this.autoSyncFailureNoticed = false;
+            companionSnapshot = await this.captureFromRuntime(runtime);
             this.notice(this.formatVaultResult(result), 10000);
           } finally {
             progress.hide();
           }
         }),
       );
+      if (companionSnapshot) this.queueCompanionReconciliation(companionSnapshot);
     } catch (error) {
       this.captureErrorStatus(error);
       this.showError(error);
@@ -689,6 +748,7 @@ export class ObsidianSemanticController {
 
   async indexCurrentNote(): Promise<void> {
     if (!this.ensureEnabled() || !this.acquireOperation()) return;
+    let companionSnapshot: CompanionSnapshot | null = null;
     try {
       const snapshot = safeSettingsSnapshot(this.plugin.settings.semantic);
       const epoch = this.settingsEpoch;
@@ -728,6 +788,7 @@ export class ObsidianSemanticController {
           this.updateReadyStatus(runtime);
           await this.activateAutomaticSync();
           this.autoSyncFailureNoticed = false;
+          companionSnapshot = await this.captureFromRuntime(runtime, [file.path]);
           if (
             result.documentsUnchanged === 1 &&
             result.chunksEmbedded === 0 &&
@@ -752,6 +813,12 @@ export class ObsidianSemanticController {
           }
         }),
       );
+      if (companionSnapshot) {
+        this.companionService.enqueueIncremental(
+          { ...this.plugin.settings.companion },
+          { snapshot: companionSnapshot, deletePaths: [] },
+        );
+      }
     } catch (error) {
       this.captureErrorStatus(error);
       this.showError(error);
@@ -762,6 +829,7 @@ export class ObsidianSemanticController {
 
   async clearIndex(): Promise<void> {
     if (!this.ensureEnabled() || !this.acquireOperation()) return;
+    let companionSnapshot: CompanionSnapshot | null = null;
     try {
       const snapshot = safeSettingsSnapshot(this.plugin.settings.semantic);
       const epoch = this.settingsEpoch;
@@ -798,6 +866,7 @@ export class ObsidianSemanticController {
               return;
             }
             await runtime.clear();
+            companionSnapshot = await this.captureFromRuntime(runtime);
             this.updateReadyStatus(runtime);
             this.notice(tr("Семантический индекс очищен."));
           });
@@ -809,6 +878,7 @@ export class ObsidianSemanticController {
           }
         }
       });
+      if (companionSnapshot) this.queueCompanionReconciliation(companionSnapshot);
     } catch (error) {
       this.captureErrorStatus(error);
       this.showError(error);
@@ -819,6 +889,7 @@ export class ObsidianSemanticController {
 
   async rebuildIndex(): Promise<void> {
     if (!this.ensureEnabled() || !this.acquireOperation()) return;
+    let companionSnapshot: CompanionSnapshot | null = null;
     try {
       const fileCount = this.plugin.app.vault.getMarkdownFiles().length;
       const snapshot = safeSettingsSnapshot(this.plugin.settings.semantic);
@@ -864,12 +935,14 @@ export class ObsidianSemanticController {
             this.updateReadyStatus(runtime);
             await this.activateAutomaticSync();
             this.autoSyncFailureNoticed = false;
+            companionSnapshot = await this.captureFromRuntime(runtime);
             this.notice(this.formatVaultResult(result), 10000);
           } finally {
             progress.hide();
           }
         }),
       );
+      if (companionSnapshot) this.queueCompanionReconciliation(companionSnapshot);
     } catch (error) {
       this.captureErrorStatus(error);
       this.showError(error);
@@ -935,8 +1008,12 @@ export class ObsidianSemanticController {
     const oldWasMarkdown = isMarkdownPath(oldPath);
     const newIsMarkdown = isMarkdownTFile(file);
     if (oldWasMarkdown && newIsMarkdown) {
+      const origin = this.pendingCompanionRenames.get(oldPath) ?? oldPath;
+      this.pendingCompanionRenames.delete(oldPath);
+      this.pendingCompanionRenames.set(file.path, origin);
       this.autoSync.rename(oldPath, file.path);
     } else if (oldWasMarkdown) {
+      this.pendingCompanionRenames.delete(oldPath);
       this.autoSync.delete(oldPath);
     } else if (newIsMarkdown) {
       this.autoSync.upsert(file.path);
@@ -981,6 +1058,9 @@ export class ObsidianSemanticController {
   private async flushAutomaticSync(
     batch: SemanticAutoSyncBatch,
   ): Promise<void> {
+    const companionChange: { value: CompanionIncrementalChange | null } = {
+      value: null,
+    };
     await this.enqueueIndexMutation(() =>
       this.barrier.withShared(async () => {
         if (
@@ -1021,8 +1101,40 @@ export class ObsidianSemanticController {
         if (!shouldCommit()) return;
         this.updateReadyStatus(runtime);
         this.autoSyncFailureNoticed = false;
+        const mirror = await this.captureFromRuntime(
+          runtime,
+          batch.reconcileAll ? undefined : batch.upsertPaths,
+        );
+        if (!mirror) return;
+        if (batch.reconcileAll) {
+          this.pendingCompanionRenames.clear();
+          companionChange.value = { snapshot: mirror, deletePaths: [] };
+          return;
+        }
+        const renames: Array<{ oldPath: string; newPath: string }> = [];
+        for (const newPath of batch.upsertPaths) {
+          const oldPath = this.pendingCompanionRenames.get(newPath);
+          if (!oldPath || !batch.deletePaths.includes(oldPath)) continue;
+          renames.push({ oldPath, newPath });
+          this.pendingCompanionRenames.delete(newPath);
+        }
+        companionChange.value = {
+          snapshot: mirror,
+          deletePaths: [...batch.deletePaths],
+          renames,
+        };
       }),
     );
+    const change = companionChange.value;
+    if (!change) return;
+    if (batch.reconcileAll) {
+      this.queueCompanionReconciliation(change.snapshot);
+    } else {
+      this.companionService.enqueueIncremental(
+        { ...this.plugin.settings.companion },
+        change,
+      );
+    }
   }
 
   private handleAutomaticSyncError(error: unknown): void {
@@ -1075,6 +1187,62 @@ export class ObsidianSemanticController {
         "Semantic automatic-sync state could not be persisted safely.",
       );
     }
+  }
+
+  private async captureCompanionSnapshot(): Promise<CompanionSnapshot | null> {
+    if (
+      !this.plugin.settings.companion.enabled ||
+      !this.plugin.settings.semantic.enabled
+    ) {
+      return null;
+    }
+    return this.barrier.withShared(async () => {
+      const snapshot = safeSettingsSnapshot(this.plugin.settings.semantic);
+      const runtime = await this.runtimeForSnapshot(
+        snapshot,
+        this.settingsEpoch,
+        "search",
+      );
+      if (!runtime) return null;
+      if (!runtime.getStats().initialized) await runtime.initialize();
+      if (runtime.getStats().vectorCount <= 0) return null;
+      return runtime.captureCompanionSnapshot?.() ?? null;
+    });
+  }
+
+  private captureFromRuntime(
+    runtime: SemanticRuntime,
+    paths?: readonly string[],
+  ): Promise<CompanionSnapshot | null> {
+    if (!this.plugin.settings.companion.enabled) return Promise.resolve(null);
+    return runtime.captureCompanionSnapshot?.(paths) ?? Promise.resolve(null);
+  }
+
+  private queueCompanionReconciliation(snapshot: CompanionSnapshot): void {
+    const settings = { ...this.plugin.settings.companion };
+    if (!settings.enabled) return;
+    void this.companionService.reconcile(settings, snapshot).catch(() => {
+      // Companion is optional; status is retained by the service for the UI.
+    });
+  }
+
+  private async reconcileCompanionQuietly(): Promise<void> {
+    try {
+      const snapshot = await this.captureCompanionSnapshot();
+      if (snapshot) this.queueCompanionReconciliation(snapshot);
+    } catch {
+      // Startup reconciliation is best effort and never initializes an absent index.
+    }
+  }
+
+  private companionErrorMessage(error: unknown): string {
+    if (error instanceof CompanionClientError) {
+      if (error.code === "AUTH_REQUIRED") return tr("Companion rejected the Bearer token.");
+      if (error.code === "PROTOCOL_VERSION_MISMATCH") return tr("Companion protocol version is incompatible.");
+      if (error.code === "CONFIGURATION_ERROR") return tr("Check the Companion endpoint, HTTPS requirement, token, and timeout.");
+      if (error.code === "TIMEOUT") return tr("Companion request timed out.");
+    }
+    return tr("Companion is unavailable. Local Vault features remain active.");
   }
 
   private enqueueIndexMutation(operation: () => Promise<void>): Promise<void> {

--- a/semantic/obsidianSemanticController.ts
+++ b/semantic/obsidianSemanticController.ts
@@ -449,7 +449,7 @@ export class ObsidianSemanticController {
   }
 
   notifyCompanionSettingsChanged(): void {
-    // Client configuration is snapshotted per request; editing settings never uploads data.
+    this.companionService.invalidateConfiguration();
   }
 
   async testCompanionConnection(signal?: AbortSignal): Promise<void> {

--- a/semantic/obsidianSemanticRuntime.ts
+++ b/semantic/obsidianSemanticRuntime.ts
@@ -9,6 +9,7 @@ import {
   IndexingCompatibilityError,
   IndexingService,
   ObsidianMarkdownDocumentSource,
+  normalizeEmbeddingBaseUrl,
 } from "../indexing";
 import {
   LocalVectorStore,
@@ -141,6 +142,15 @@ export function createObsidianSemanticRuntime(
       vectorStore: store,
       source,
       ragContextBuilder: new RagContextBuilder(searchService, source, chunker),
+      chunker,
+      companionDescriptor: {
+        providerId: provider.id,
+        model: provider.model,
+        baseUrl: normalizeEmbeddingBaseUrl(settings.embeddingBaseUrl),
+        dimensions: stats.dimensions,
+        embeddingSpaceId: stats.embeddingSpaceId,
+        normalized: true,
+      },
     };
   });
 }

--- a/semantic/semanticConcurrency.integration.test.ts
+++ b/semantic/semanticConcurrency.integration.test.ts
@@ -65,6 +65,9 @@ import {
 } from "./semanticStorageMaintenance";
 import { SemanticStoreRegistry } from "./semanticStoreRegistry";
 import type { SemanticRuntime } from "./types";
+import { AsyncReadWriteBarrier } from "./asyncReadWriteBarrier";
+import type { CompanionSyncPort } from "../companionSync";
+import type { SemanticControllerDependencies } from "./obsidianSemanticController";
 
 const BASE_PATH = semanticIndexBasePath(".obsidian", "ai-knowledge-hub");
 
@@ -297,6 +300,7 @@ function createHarness(
   initialSettings = semantic(),
   adapter = new MemoryDataAdapter(),
   autoSyncSuspended = false,
+  dependencyOverrides: SemanticControllerDependencies = {},
 ) {
   const registry = new SemanticStoreRegistry();
   const notices: string[] = [];
@@ -345,6 +349,13 @@ function createHarness(
   const pluginSettings = {
     semantic: initialSettings,
     semanticAutoSyncSuspended: autoSyncSuspended,
+    companion: {
+      enabled: false,
+      endpoint: "http://127.0.0.1:27124",
+      token: "",
+      timeoutMs: 5000,
+      vaultId: "11111111-1111-4111-8111-111111111111",
+    },
   };
   const plugin = {
     app,
@@ -374,6 +385,7 @@ function createHarness(
     resetStorage,
     storeRegistry: registry,
     autoSyncDebounceMs: 10,
+    ...dependencyOverrides,
   });
   return {
     adapter,
@@ -1677,5 +1689,123 @@ describe("automatic semantic index synchronization", () => {
     expect(harness.registry.peek(BASE_PATH)?.store.getStats().generation).toBe(
       generation,
     );
+  });
+
+  it("a slow Companion never blocks AutoSync, search, discovery, Clear, or Rebuild", async () => {
+    const slow = manualGate();
+    const companion: CompanionSyncPort = {
+      getStatus: vi.fn(() => ({ kind: "syncing" as const })),
+      testConnection: vi.fn(async () => undefined),
+      reconcile: vi.fn(async () => { await slow.wait; }),
+      enqueueIncremental: vi.fn(),
+      dispose: vi.fn(async () => undefined),
+    };
+    const harness = createHarness(semantic(), new MemoryDataAdapter(), false, {
+      companionService: companion,
+    });
+    harness.plugin.settings.companion.enabled = true;
+    harness.plugin.settings.companion.token = "companion-secret";
+    harness.registerAutomaticSync();
+
+    await harness.controller.indexVault();
+    expect(companion.reconcile).toHaveBeenCalledOnce();
+    await expect(harness.controller.search("alpha")).resolves.toHaveLength(1);
+    await expect(harness.controller.findSimilarNotes("Alpha.md")).resolves.toEqual([]);
+    await expect(harness.controller.findPotentialDuplicates()).resolves.toEqual([]);
+
+    harness.modifyFile("Alpha.md", "# Alpha\n\nbeta while companion is slow");
+    await drainAutomaticSync();
+    expect(companion.enqueueIncremental).toHaveBeenCalledOnce();
+    await expect(harness.controller.search("beta")).resolves.toHaveLength(1);
+
+    await expect(harness.controller.clearIndex()).resolves.toBeUndefined();
+    await expect(harness.controller.rebuildIndex()).resolves.toBeUndefined();
+    expect(companion.reconcile).toHaveBeenCalledTimes(3);
+    slow.release();
+  });
+
+  it("starts every Companion network handoff after releasing the semantic barrier", async () => {
+    class TrackingBarrier extends AsyncReadWriteBarrier {
+      insideShared = false;
+
+      override withShared<T>(operation: () => Promise<T>): Promise<T> {
+        return super.withShared(async () => {
+          this.insideShared = true;
+          try {
+            return await operation();
+          } finally {
+            this.insideShared = false;
+          }
+        });
+      }
+    }
+    const barrier = new TrackingBarrier();
+    const observed: boolean[] = [];
+    const companion: CompanionSyncPort = {
+      getStatus: vi.fn(() => ({ kind: "idle" as const })),
+      testConnection: vi.fn(async () => undefined),
+      reconcile: vi.fn(async () => { observed.push(barrier.insideShared); }),
+      enqueueIncremental: vi.fn(() => { observed.push(barrier.insideShared); }),
+      dispose: vi.fn(async () => undefined),
+    };
+    const harness = createHarness(semantic(), new MemoryDataAdapter(), false, {
+      barrier,
+      companionService: companion,
+    });
+    harness.plugin.settings.companion.enabled = true;
+    harness.registerAutomaticSync();
+
+    await harness.controller.indexVault();
+    harness.modifyFile("Alpha.md", "# Alpha\n\ngamma after local commit");
+    await drainAutomaticSync();
+
+    expect(observed).toEqual([false, false]);
+  });
+
+  it("quietly reconciles Companion on startup only when a usable index already exists", async () => {
+    const first = createHarness();
+    await first.controller.indexVault();
+    const companion: CompanionSyncPort = {
+      getStatus: vi.fn(() => ({ kind: "idle" as const })),
+      testConnection: vi.fn(async () => undefined),
+      reconcile: vi.fn(async () => undefined),
+      enqueueIncremental: vi.fn(),
+      dispose: vi.fn(async () => undefined),
+    };
+    const restarted = createHarness(semantic(), first.adapter, false, {
+      companionService: companion,
+    });
+    restarted.plugin.settings.companion.enabled = true;
+    embeddingCalls = [];
+    restarted.registerAutomaticSync();
+    restarted.fireLayoutReady();
+    await vi.advanceTimersByTimeAsync(20);
+    await flushMicrotasks();
+
+    expect(companion.reconcile).toHaveBeenCalled();
+    expect(embeddingCalls).toEqual([]);
+  });
+
+  it("does not build an absent semantic index merely because Companion is enabled", async () => {
+    const companion: CompanionSyncPort = {
+      getStatus: vi.fn(() => ({ kind: "idle" as const })),
+      testConnection: vi.fn(async () => undefined),
+      reconcile: vi.fn(async () => undefined),
+      enqueueIncremental: vi.fn(),
+      dispose: vi.fn(async () => undefined),
+    };
+    const harness = createHarness(semantic(), new MemoryDataAdapter(), false, {
+      companionService: companion,
+    });
+    harness.plugin.settings.companion.enabled = true;
+    embeddingCalls = [];
+    harness.registerAutomaticSync();
+    harness.fireLayoutReady();
+    await vi.advanceTimersByTimeAsync(20);
+    await flushMicrotasks();
+
+    expect(companion.reconcile).not.toHaveBeenCalled();
+    expect(embeddingCalls).toEqual([]);
+    expect(harness.registry.size).toBe(0);
   });
 });

--- a/semantic/semanticConcurrency.integration.test.ts
+++ b/semantic/semanticConcurrency.integration.test.ts
@@ -1695,6 +1695,7 @@ describe("automatic semantic index synchronization", () => {
     const slow = manualGate();
     const companion: CompanionSyncPort = {
       getStatus: vi.fn(() => ({ kind: "syncing" as const })),
+      invalidateConfiguration: vi.fn(),
       testConnection: vi.fn(async () => undefined),
       reconcile: vi.fn(async () => { await slow.wait; }),
       enqueueIncremental: vi.fn(),
@@ -1743,6 +1744,7 @@ describe("automatic semantic index synchronization", () => {
     const observed: boolean[] = [];
     const companion: CompanionSyncPort = {
       getStatus: vi.fn(() => ({ kind: "idle" as const })),
+      invalidateConfiguration: vi.fn(),
       testConnection: vi.fn(async () => undefined),
       reconcile: vi.fn(async () => { observed.push(barrier.insideShared); }),
       enqueueIncremental: vi.fn(() => { observed.push(barrier.insideShared); }),
@@ -1767,6 +1769,7 @@ describe("automatic semantic index synchronization", () => {
     await first.controller.indexVault();
     const companion: CompanionSyncPort = {
       getStatus: vi.fn(() => ({ kind: "idle" as const })),
+      invalidateConfiguration: vi.fn(),
       testConnection: vi.fn(async () => undefined),
       reconcile: vi.fn(async () => undefined),
       enqueueIncremental: vi.fn(),
@@ -1789,6 +1792,7 @@ describe("automatic semantic index synchronization", () => {
   it("does not build an absent semantic index merely because Companion is enabled", async () => {
     const companion: CompanionSyncPort = {
       getStatus: vi.fn(() => ({ kind: "idle" as const })),
+      invalidateConfiguration: vi.fn(),
       testConnection: vi.fn(async () => undefined),
       reconcile: vi.fn(async () => undefined),
       enqueueIncremental: vi.fn(),

--- a/semantic/semanticRuntime.test.ts
+++ b/semantic/semanticRuntime.test.ts
@@ -209,6 +209,15 @@ function createIntegrationHarness() {
         source,
         chunker,
       ),
+      chunker,
+      companionDescriptor: {
+        providerId: provider.id,
+        model: provider.model,
+        baseUrl: "https://example.test/v1",
+        dimensions: stats.dimensions,
+        embeddingSpaceId: stats.embeddingSpaceId,
+        normalized: true as const,
+      },
     };
   });
 
@@ -323,6 +332,48 @@ describe("LazySemanticRuntime", () => {
     expect(harness.runtime.getStats().vectorCount).toBe(1);
     const results = await harness.runtime.search("beta");
     expect(results.map((result) => result.path)).toEqual(["Only.md"]);
+  });
+
+  it("captures full Companion state from committed vectors with zero extra embedding calls", async () => {
+    const harness = createIntegrationHarness();
+    await harness.runtime.indexVault();
+    const embeddingCallsBefore = harness.provider.embedCalls.length;
+
+    const snapshot = await harness.runtime.captureCompanionSnapshot?.();
+
+    expect(harness.provider.embedCalls).toHaveLength(embeddingCallsBefore);
+    expect(snapshot).toMatchObject({
+      generation: 1,
+      descriptor: {
+        providerId: "openai-compatible",
+        model: "semantic-test",
+        dimensions: 3,
+        normalized: true,
+      },
+      notes: [{
+        path: "Alpha.md",
+        content: "alpha text",
+        chunks: [{
+          chunkId: "Alpha.md:0",
+          text: "alpha text",
+          headingPath: ["Alpha"],
+          source: { startOffset: 0, endOffset: 10, startLine: 0, endLine: 0 },
+          embedding: [1, 0, 0],
+        }],
+      }],
+    });
+  });
+
+  it("omits locally stale note text instead of pairing it with old vectors", async () => {
+    const harness = createIntegrationHarness();
+    await harness.runtime.indexVault();
+    harness.source.documents[0] = { path: "Alpha.md", content: "changed without index commit" };
+    const embeddingCallsBefore = harness.provider.embedCalls.length;
+
+    const snapshot = await harness.runtime.captureCompanionSnapshot?.();
+
+    expect(snapshot?.notes).toEqual([]);
+    expect(harness.provider.embedCalls).toHaveLength(embeddingCallsBefore);
   });
 
   it("clears the compatible store and reports updated stats", async () => {

--- a/semantic/semanticRuntime.ts
+++ b/semantic/semanticRuntime.ts
@@ -1,5 +1,12 @@
 import type { RagContextBuilder } from "../rag/ragContextBuilder";
 import type { RagContext } from "../rag/types";
+import { stableHash } from "../chunking/hash";
+import type { ChunkingStrategy, NoteChunk } from "../chunking/types";
+import type {
+  CompanionNote,
+  CompanionSemanticDescriptor,
+  CompanionSnapshot,
+} from "../companionSync/types";
 import type {
   IndexDocumentInput,
   IndexingExecutionOptions,
@@ -34,6 +41,8 @@ export interface SemanticRuntimeComponents {
   vectorStore: VectorStore;
   source: MarkdownDocumentSource;
   ragContextBuilder: RagContextBuilder;
+  chunker?: ChunkingStrategy;
+  companionDescriptor?: CompanionSemanticDescriptor;
 }
 
 export type SemanticRuntimeInitializer =
@@ -152,6 +161,69 @@ export class LazySemanticRuntime implements SemanticRuntime {
     return this.requireDiscoveryService().findPotentialDuplicates(options);
   }
 
+  async captureCompanionSnapshot(
+    paths?: readonly string[],
+  ): Promise<CompanionSnapshot> {
+    await this.initialize();
+    const components = this.requireComponents();
+    if (!components.chunker || !components.companionDescriptor) {
+      throw new SemanticNotReadyError("Semantic mirror capture is unavailable.");
+    }
+    const chunker = components.chunker;
+    const companionDescriptor = components.companionDescriptor;
+    const snapshot = components.vectorStore.readSnapshot();
+    const indexedPaths = new Set(snapshot.metadata.map((item) => item.path));
+    const requestedPaths = paths
+      ? [...new Set(paths)].filter((path) => indexedPaths.has(path)).sort()
+      : [...indexedPaths].sort();
+    const selection = await components.source.readPaths(requestedPaths);
+    const vectorsById = new Map<string, number[]>();
+    for (let index = 0; index < snapshot.metadata.length; index++) {
+      const metadata = snapshot.metadata[index];
+      if (!metadata) continue;
+      const start = index * snapshot.dimensions;
+      vectorsById.set(
+        metadata.id,
+        Array.from(snapshot.vectors.slice(start, start + snapshot.dimensions)),
+      );
+    }
+    const metadataByPath = new Map<string, typeof snapshot.metadata>();
+    for (const metadata of snapshot.metadata) {
+      const current = metadataByPath.get(metadata.path) ?? [];
+      current.push(metadata);
+      metadataByPath.set(metadata.path, current);
+    }
+    const notes: CompanionNote[] = [];
+    for (const document of selection.documents.sort((left, right) => left.path.localeCompare(right.path))) {
+      const chunks = chunker.chunk(document);
+      const stored = metadataByPath.get(document.path) ?? [];
+      if (chunks.length !== stored.length || !chunks.every((chunk) => this.chunkMatchesStored(chunk, stored))) {
+        continue;
+      }
+      notes.push({
+        path: document.path,
+        content: document.content,
+        contentHash: stableHash(document.content),
+        metadata: {},
+        chunks: chunks.map((chunk) => ({
+          chunkId: chunk.id,
+          notePath: chunk.path,
+          ordinal: chunk.ordinal,
+          headingPath: [...chunk.headingPath],
+          text: chunk.text,
+          contentHash: chunk.contentHash,
+          source: { ...chunk.source },
+          embedding: [...(vectorsById.get(chunk.id) ?? [])],
+        })),
+      });
+    }
+    return {
+      generation: snapshot.generation,
+      descriptor: { ...companionDescriptor },
+      notes,
+    };
+  }
+
   async clear(): Promise<void> {
     await this.initialize();
     await this.requireComponents().vectorStore.clear();
@@ -222,5 +294,24 @@ export class LazySemanticRuntime implements SemanticRuntime {
   private requireDiscoveryService(): SemanticDiscoveryService {
     if (!this.discoveryService) throw new SemanticNotReadyError();
     return this.discoveryService;
+  }
+
+  private chunkMatchesStored(
+    chunk: NoteChunk,
+    stored: ReturnType<VectorStore["listMetadata"]>,
+  ): boolean {
+    const metadata = stored.find((item) => item.id === chunk.id);
+    return Boolean(
+      metadata &&
+      metadata.path === chunk.path &&
+      metadata.ordinal === chunk.ordinal &&
+      metadata.contentHash === chunk.contentHash &&
+      metadata.headingPath.length === chunk.headingPath.length &&
+      metadata.headingPath.every((heading, index) => heading === chunk.headingPath[index]) &&
+      metadata.source.startOffset === chunk.source.startOffset &&
+      metadata.source.endOffset === chunk.source.endOffset &&
+      metadata.source.startLine === chunk.source.startLine &&
+      metadata.source.endLine === chunk.source.endLine
+    );
   }
 }

--- a/semantic/types.ts
+++ b/semantic/types.ts
@@ -5,6 +5,7 @@ import type {
   IndexingExecutionOptions,
   IndexingRunResult,
 } from "../indexing/types";
+import type { CompanionSnapshot } from "../companionSync/types";
 
 export interface SemanticSearchOptions {
   limit?: number;
@@ -94,6 +95,10 @@ export interface SemanticRuntime {
   findPotentialDuplicates: (
     options?: SemanticDuplicateOptions,
   ) => Promise<SemanticDuplicatePair[]>;
+  /** Materializes note text, chunk text, metadata, and existing vectors without embedding. */
+  captureCompanionSnapshot?: (
+    paths?: readonly string[],
+  ) => Promise<CompanionSnapshot>;
   clear: () => Promise<void>;
   getStats: () => SemanticRuntimeStats;
 }

--- a/settings.ts
+++ b/settings.ts
@@ -27,6 +27,11 @@ import {
   semanticControlDisabled,
   SemanticSettingsActionRunner,
 } from "./semantic/semanticSettingsActionRunner";
+import {
+  DEFAULT_COMPANION_SETTINGS,
+  isLocalCompanionEndpoint,
+} from "./companionSync";
+import type { CompanionSettings } from "./companionSync";
 
 export type InsertionType =
   | "end"
@@ -69,6 +74,8 @@ export interface AIHubSettings {
   semantic: EmbeddingSettings;
   /** Clear keeps automatic sync suspended until a later explicit index run. */
   semanticAutoSyncSuspended: boolean;
+  /** Optional read-only network mirror used by the standalone Companion. */
+  companion: CompanionSettings;
 }
 
 export const DEFAULT_SETTINGS: AIHubSettings = {
@@ -94,6 +101,7 @@ export const DEFAULT_SETTINGS: AIHubSettings = {
   },
   semantic: { ...DEFAULT_EMBEDDING_SETTINGS },
   semanticAutoSyncSuspended: false,
+  companion: { ...DEFAULT_COMPANION_SETTINGS },
 };
 
 // ─────────────────────────────────────────────────────────────────────
@@ -170,6 +178,11 @@ export class AIHubSettingTab extends PluginSettingTab {
     // ── Секция: embeddings ───────────────────────────────────────────
     this.addHeading(tr("Embeddings"), "binary");
     this.renderEmbeddingsSection(save);
+
+    containerEl.createEl("hr", { cls: "ai-hub-settings-separator" });
+
+    this.addHeading(tr("Companion"), "server");
+    this.renderCompanionSection(save);
 
     containerEl.createEl("hr", { cls: "ai-hub-settings-separator" });
 
@@ -914,6 +927,90 @@ export class AIHubSettingTab extends PluginSettingTab {
         ),
       );
     this.addIcon(actions, "search");
+  }
+
+  private renderCompanionSection(save: () => Promise<void>): void {
+    const companion = this.plugin.settings.companion;
+    const controller = this.plugin.getSemanticController();
+
+    this.addIcon(
+      new Setting(this.containerEl)
+        .setName(tr("Включить Companion"))
+        .setDesc(tr("Опционально передаёт read-only mirror текущего semantic index настроенному Companion endpoint. Первый sync запускается явно."))
+        .addToggle((toggle) => toggle.setValue(companion.enabled).onChange(async (value) => {
+          companion.enabled = value;
+          controller.notifyCompanionSettingsChanged();
+          await save();
+          this.display();
+        })),
+      "power",
+    );
+
+    this.addIcon(
+      new Setting(this.containerEl)
+        .setName(tr("Companion endpoint"))
+        .setDesc(tr("Локально: http://127.0.0.1:27124. Remote endpoint должен использовать HTTPS."))
+        .addText((text) => text
+          .setPlaceholder(DEFAULT_COMPANION_SETTINGS.endpoint)
+          .setValue(companion.endpoint)
+          .onChange(async (value) => {
+            companion.endpoint = value.trim();
+            controller.notifyCompanionSettingsChanged();
+            await save();
+          })),
+      "link",
+    );
+
+    this.addIcon(
+      new Setting(this.containerEl)
+        .setName(tr("Companion token"))
+        .setDesc(tr("Отдельный Bearer token Companion. Хранится локально в данных плагина и никогда не отправляется AI-провайдерам."))
+        .addText((text) => {
+          text.inputEl.type = "password";
+          text.inputEl.setAttribute("autocomplete", "off");
+          return text.setPlaceholder("••••••••••••").setValue(companion.token).onChange(async (value) => {
+            companion.token = value.trim();
+            controller.notifyCompanionSettingsChanged();
+            await save();
+          });
+        }),
+      "key",
+    );
+
+    if (companion.endpoint && !isLocalCompanionEndpoint(companion.endpoint)) {
+      const warning = this.containerEl.createDiv({ cls: "ai-hub-info-card" });
+      warning.setText(tr("Remote Companion получает vault-relative пути, Markdown, chunk text, metadata и embeddings. Используйте только HTTPS и доверенный сервер."));
+    }
+
+    const state = controller.getCompanionStatus();
+    const labels = {
+      disabled: tr("Выключен"),
+      idle: tr("Ожидает sync"),
+      syncing: tr("Синхронизация..."),
+      ready: tr("Готов"),
+      error: tr("Ошибка"),
+    };
+    const row = new Setting(this.containerEl)
+      .setName(tr("Companion connection"))
+      .setDesc(`${tr("Статус: {status}", { status: labels[state.kind] })}${state.code ? ` (${state.code})` : ""}`)
+      .addButton((button) => button
+        .setButtonText(tr("Проверить соединение"))
+        .setIcon("plug-zap")
+        .onClick(() => {
+          void controller.testCompanionConnection().finally(() => {
+            if (this.containerEl.isConnected) this.display();
+          });
+        }))
+      .addButton((button) => button
+        .setButtonText(tr("Sync now"))
+        .setIcon("refresh-cw")
+        .setDisabled(!companion.enabled)
+        .onClick(() => {
+          void controller.syncCompanionNow().finally(() => {
+            if (this.containerEl.isConnected) this.display();
+          });
+        }));
+    this.addIcon(row, "server");
   }
 
   private async runSemanticControlAction(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,5 +20,5 @@
     "useUnknownInCatchVariables": true
   },
   "include": ["**/*.ts"],
-  "exclude": ["node_modules", "*.js"]
+  "exclude": ["node_modules", "companion", "*.js"]
 }


### PR DESCRIPTION
## Summary

- add a self-contained Node.js 24 + TypeScript Companion under `companion/`
- persist versioned, authenticated semantic mirrors in SQLite with explicit migrations and vault isolation
- add deterministic full reconciliation plus bounded idempotent UPSERT/DELETE/RENAME batches
- add one opt-in Obsidian Companion client/settings flow that reuses committed embeddings and performs network I/O after releasing semantic barriers
- invalidate obsolete queued sync work whenever Companion configuration changes
- document local, sparse-checkout, and HTTPS reverse-proxy VPS deployment

## Configuration-race hardening

`CompanionSyncService` now captures a configuration epoch for each reconciliation and incremental operation. Changing Companion enablement, endpoint, token, timeout, or identity invalidates the epoch. Obsolete work is discarded before its first request, after reconciliation planning, before every batch, and before/after retry backoff. Already-started `requestUrl` transport may physically finish, but it cannot trigger another request, retry, plan-to-batch transition, or later batch. Intentional invalidation returns to idle/disabled status instead of recording a server error.

Permanent tests cover queued incremental invalidation, invalidation after plan, multi-batch cancellation, retry cancellation, use of new connection settings, disabled status, and controller invalidation wiring.

## Safety and compatibility

- Companion remains disabled by default and never reads or writes the Vault filesystem
- disabling synchronization does not delete the local semantic index or persisted Companion mirror
- local semantic commit always precedes optional network mirroring
- provider credentials are never sent; Companion tokens and generic errors are redacted
- no MCP, write-back, agents, Qdrant, external database, or plugin version bump
- existing plugin lint warning allowance is unchanged (the same two baseline warnings remain)

## Validation

- plugin: lint, typecheck, 730 tests, and production build pass
- Companion: zero-warning lint, typecheck, 38 tests, and build pass
- fresh HTTPS GitHub sparse checkout of only `companion/` passes `npm ci`, lint, typecheck, tests, and build at `2eadc44de108c68ec0baf74d9a2bb9c5afbd725d`
- headless/live Companion smoke remains valid: health/auth/protocol, reconciliation, UPSERT/DELETE/RENAME, embeddings, atomic rejection, offline repair, no-op convergence, and SQLite restart durability
- desktop Obsidian UI smoke: pending user verification
- adversarial mutation audit: all 11 required invariant mutations were detected by permanent tests and immediately reverted
