### PR TITLE
feat(companion): add optional Qdrant vector search adapter

### DIFF
--- a/companion/README.md
+++ b/companion/README.md
@@ -157,7 +157,7 @@ The plugin never transmits its embedding or language-model API keys. Provision a
 
 Each non-empty search calls `QueryEmbeddingProvider.embedQuery` **once**, sending only `[query]`. It never sends stored note/chunk text for embedding and never probes dimensions with a second request. Empty mirrors/chunk sets make zero calls. The other four tools make zero embedding calls. A missing/incompatible provider or invalid response produces a clean `SEMANTIC_SEARCH_UNAVAILABLE` tool error while reading/listing remains available.
 
-Search validates the canonical descriptor identity, supported provider, dimensions, finite Float32 values, and nonzero query norm. If the provider reports a model, it must match exactly, with one narrow OpenRouter exception: remove at most one leading `private/openrouter/` from the reported name and allow a terminal `:free` on the requested name to be absent in the response; the underlying identifier must still match exactly. No other namespaces, suffixes, case changes, or different models are accepted. Requests and the persisted descriptor/embedding-space ID retain the original configured model; no reindex is needed. Stored vectors must be unit-normalized within `1e-4`. The query is normalized into Float32 and dot products are clamped to `[-1, 1]`, matching the plugin's cosine semantics. Scores sort descending, with chunk ID ascending as the stable tie-break. The SQLite scan retains only top K vectors and reads winner text afterwards. A descriptor/generation change during the query request rejects the search rather than comparing incompatible spaces. No index is rebuilt. There is no ANN or second vector database; scanning is linear and intended for small/medium personal Vaults.
+Search validates the canonical descriptor identity, supported provider, dimensions, finite Float32 values, and nonzero query norm. If the provider reports a model, it must match exactly, with one narrow OpenRouter exception: remove at most one leading `private/openrouter/` from the reported name and allow a terminal `:free` on the requested name to be absent in the response; the underlying identifier must still match exactly. No other namespaces, suffixes, case changes, or different models are accepted. Requests and the persisted descriptor/embedding-space ID retain the original configured model; no reindex is needed. Stored vectors must be unit-normalized within `1e-4`. The query is normalized into Float32 and dot products are clamped to `[-1, 1]`, matching the plugin's cosine semantics. Scores sort descending, with chunk ID ascending as the stable tie-break. The SQLite scan retains only top K vectors and reads winner text afterwards. A descriptor/generation change during the query request rejects the search rather than comparing incompatible spaces. With Qdrant disabled, retrieval uses the permanent SQLite linear scan. Optional Qdrant acceleration uses the same query vector and hydrates every winner from SQLite; see below.
 
 ### Client configuration
 
@@ -306,6 +306,81 @@ Each real chunk also carries `chunkId`, `notePath`, `ordinal`, `headingPath`, fu
 ```
 
 Requests are bounded to 16 MiB, 100 operations per batch, 4 MiB per note, and 10,000 chunks per note.
+
+## Optional Qdrant acceleration
+
+Qdrant is **optional, disabled by default, and a derived, rebuildable vector-search index**. SQLite remains the authoritative persistent mirror for Markdown, note/chunk identity, text, metadata, stored vectors, semantic descriptor, generation and synchronization. The plugin only talks to Companion and has no Qdrant settings. The MCP tools and `search_vault({ query, limit? })` inputs are unchanged; backend selection is server policy.
+
+Companion uses the official [`@qdrant/js-client-rest`](https://github.com/qdrant/qdrant-js) client, pinned to **1.19.0**, through a narrow adapter. Use Qdrant **1.19.x** with collection metadata support. An incompatible server or collection leaves retrieval on SQLite. All dependencies live in `companion/`; the same build runs locally or on a Linux VPS. Docker is not a Companion runtime requirement.
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `QDRANT_ENABLED` | `false` | Enable the derived index for the one configured `MCP_VAULT_ID`. |
+| `QDRANT_URL` | `http://127.0.0.1:6333` | Qdrant HTTP(S) endpoint, optionally with a reverse-proxy path. URL credentials, query strings and fragments are rejected. |
+| `QDRANT_API_KEY` | empty | Server-side Qdrant credential. Keep in a protected environment file; never in plugin settings. |
+| `QDRANT_TIMEOUT_MS` | `5000` | Per-request timeout, 100–120000 ms. Requests are not retried. |
+| `QDRANT_COLLECTION_PREFIX` | `vault_audit` | 1–32 ASCII letters, digits or underscores. Use separate prefixes for separate Companion deployments. |
+| `QDRANT_ALLOW_INSECURE_REMOTE_HTTP` | `false` | Explicit opt-in for plaintext HTTP beyond loopback, including private IPs. |
+
+`MCP_VAULT_ID` must be set when Qdrant is enabled, even if `/mcp` is disabled. It is the same stable UUID used by the plugin's existing Companion mirror. Other mirrored Vaults remain in SQLite. Restart Companion after configuration changes.
+
+A local configuration, in addition to the normal Companion/MCP settings:
+
+```dotenv
+MCP_VAULT_ID=11111111-1111-4111-8111-111111111111
+QDRANT_ENABLED=true
+QDRANT_URL=http://127.0.0.1:6333
+QDRANT_API_KEY=
+QDRANT_TIMEOUT_MS=5000
+QDRANT_COLLECTION_PREFIX=vault_audit
+QDRANT_ALLOW_INSECURE_REMOTE_HTTP=false
+```
+
+Run Qdrant separately using its native binary or your existing service manager. An optional local development container can be started with:
+
+```sh
+docker run --rm --name vault-qdrant -p 127.0.0.1:6333:6333 qdrant/qdrant:v1.19.1
+```
+
+The container's vector data is disposable; Companion rebuilds it from SQLite. Keep the authoritative Companion `DATA_DIR` persistent and backed up.
+
+For a VPS with a protected HTTPS endpoint reachable on private networking:
+
+```dotenv
+MCP_VAULT_ID=11111111-1111-4111-8111-111111111111
+QDRANT_ENABLED=true
+QDRANT_URL=https://qdrant.internal.example
+QDRANT_API_KEY=replace-with-a-private-server-side-key
+QDRANT_TIMEOUT_MS=5000
+QDRANT_COLLECTION_PREFIX=vault_audit_vps
+QDRANT_ALLOW_INSECURE_REMOTE_HTTP=false
+```
+
+Prefer HTTPS and firewall/private-network restrictions in production. Loopback plaintext is accepted. If an isolated private network deliberately uses `http://10.0.0.12:6333`, set `QDRANT_ALLOW_INSECURE_REMOTE_HTTP=true`; that explicitly permits transmitting the key in plaintext on that network. HTTP redirects are refused for every SDK operation, including HTTPS redirects, so the key cannot follow a redirect to another endpoint. Configure the final URL directly. Keys never enter SQLite, MCP output, public health, authenticated diagnostic status or upstream error text. Adapter errors retain only fixed error codes.
+
+### Readiness, rebuild and recovery
+
+HTTP and MCP start after normal SQLite initialization. Qdrant reconciliation starts independently in the background. Startup does not wait for Qdrant, and no Obsidian resync/reindex is needed when Qdrant is enabled later or recovers from an outage.
+
+The states are `DISABLED`, `BUILDING`, `READY`, `STALE` and `ERROR`. Search may use Qdrant only for an exact match of Vault, generation, internal SQLite commit revision and complete semantic descriptor (provider, model, endpoint identity, dimensions, normalized flag and `embeddingSpaceId`). The internal revision advances on every committed sync batch, including multiple batches of the same generation, without changing the public sync protocol. Failed transactions do not advance it.
+
+On each Companion process start, existing Qdrant data is distrusted and rebuilt. Rebuild reads stored SQLite vectors by chunk-ID keyset pages of at most 128 records, validates their dimensions and normalization, and uploads at most 128 points per request. It never reads Markdown for embedding, rechunks notes, changes stored vectors or calls an embedding provider. SQLite cursors are not held across network waits. The build is published `READY` only after completed writes, compatible collection metadata, exact total/current point counts, and another check of the unchanged SQLite snapshot. A unique build stamp detects older restored Qdrant snapshots and late writes from failed requests. Partial or raced builds cannot become current.
+
+Collections use `<prefix>_<128-bit SHA-256 vault hash>_<128-bit SHA-256 space hash>`, with a full SHA-256 ownership marker in collection metadata. Names contain no note paths, absolute Vault paths or Markdown. Point IDs are deterministic UUIDv8 values derived from SHA-256 of the JSON pair `[vaultId, chunkId]`. A rebuild preserves those IDs. Each point has its vector plus `chunkId`, `vaultId`, `embeddingSpaceId`, generation, revision, build stamp and a hashed note path used for deletes. Full Markdown, chunk text and source metadata remain in SQLite.
+
+Every SQLite sync transaction commits first. Its post-commit notification invalidates readiness immediately and queues secondary work. A single pending compatible change deletes the affected note identities in Qdrant, uploads their current SQLite vectors and updates the generation/revision/build stamps of the retained points. This covers UPSERT, DELETE and RENAME: Stage 8 rename deletes both old/destination records and inserts the new note. Several pending commits coalesce into one complete rebuild. Descriptor replacement selects a new collection immediately; old-space collections are never searched for the replacement descriptor.
+
+A Qdrant failure cannot roll back SQLite or turn a successfully committed sync response into a failure. Later reconciliation repairs the derived index from the mirror. One worker handles updates with no unbounded failure queue. Failed passes use capped exponential backoff (2–30 seconds); healthy indexes are checked every 30 seconds. Each pass is a finite sequence of bounded requests; periodic maintenance continues while Companion runs. Search also checks collection compatibility and exact total/current counts before querying, detecting missing, empty, stale or partially deleted indexes without waiting for maintenance. Multiple external round trips can add up to several per-request timeouts before fallback.
+
+One Companion process must own each prefix/Vault/space collection. Do not share those collections with another writer or modify their payloads/vectors manually. The ownership marker prevents clearing an unrelated collection, but is not a distributed writer lock. Old owned collections are retained after descriptor replacement. Companion does not delete collections automatically; operators may conservatively remove unused collections after checking their ownership marker and ensuring no Companion uses them. Back up SQLite; derived collections can be recreated.
+
+### Retrieval and operator status
+
+Each search creates at most **one query embedding**. Qdrant returns only candidate chunk IDs and cosine scores. Companion sorts by score descending then chunk ID ascending and reads all winning text, paths, headings and source ranges from current SQLite. Qdrant cosine scores remain in `[-1, 1]`; only Float32 roundoff up to `1e-6` outside that interval is clamped. ANN retrieval may differ from a full scan on larger datasets. Candidate retrieval is bounded (at most 257 points); if the window cuts a score tie, SQLite resolves the tie for deterministic results.
+
+Disabled, unavailable, rebuilding, stale, incompatible, malformed, timed-out or incompletely hydrated Qdrant results fall back to the permanent SQLite backend using the **same normalized query vector**. Suspicious partial results are discarded in full. A same-space commit during Qdrant retrieval can use the current SQLite snapshot; a descriptor change rejects the old query vector. No fallback re-embeds the query or stored notes. The other four read-only MCP tools always read SQLite.
+
+`GET /v1/status`, authenticated with `COMPANION_TOKEN` and `X-Companion-Protocol-Version: 1`, adds a `qdrant` object. When enabled it reports state, connectivity from the last check, collection, Vault/space identity, indexed/current generation and revision, `lastErrorCode`, `lastSuccessfulSyncAt`, and `lastSearchBackend` (`sqlite` or `qdrant`). The latter describes the most recently completed semantic search, not a caller-selectable option. A retained indexed generation/collection after failure is diagnostic history, not permission to search it. Disabled status reports `enabled: false` and `state: DISABLED`. Public `/health` stays limited to service health and protocol version, and the MCP `vault_status` output is unchanged.
 
 ## Reconciliation and vector-space rules
 

--- a/companion/package-lock.json
+++ b/companion/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@modelcontextprotocol/node": "2.0.0",
         "@modelcontextprotocol/server": "2.0.0",
+        "@qdrant/js-client-rest": "1.19.0",
         "zod": "4.2.0"
       },
       "devDependencies": {
@@ -359,6 +360,32 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/oxc-project"
+      }
+    },
+    "node_modules/@qdrant/js-client-rest": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@qdrant/js-client-rest/-/js-client-rest-1.19.0.tgz",
+      "integrity": "sha512-1+QLUHsWp+WV4PE35FLnH2ckxotWrQEqi/F3t4goF3cCThR0ZxLVtOC4OoOi/E1iyj/iIYBdbuACWMuQ15NAnA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@qdrant/openapi-typescript-fetch": "1.2.6",
+        "undici": "7.29.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.7"
+      }
+    },
+    "node_modules/@qdrant/openapi-typescript-fetch": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@qdrant/openapi-typescript-fetch/-/openapi-typescript-fetch-1.2.6.tgz",
+      "integrity": "sha512-oQG/FejNpItrxRHoyctYvT3rwGZOnK4jr3JdppO/c78ktDvkWiPXPHNsrDf33K9sZdRb6PR7gi4noIapu5q4HA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0",
+        "pnpm": ">=8"
       }
     },
     "node_modules/@rolldown/binding-android-arm-eabi": {
@@ -2366,7 +2393,6 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -2398,6 +2424,15 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {

--- a/companion/package.json
+++ b/companion/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@modelcontextprotocol/node": "2.0.0",
     "@modelcontextprotocol/server": "2.0.0",
+    "@qdrant/js-client-rest": "1.19.0",
     "zod": "4.2.0"
   }
 }

--- a/companion/scripts/mutation-audit.mjs
+++ b/companion/scripts/mutation-audit.mjs
@@ -8,7 +8,7 @@ import assert from "node:assert/strict";
 import process from "node:process";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-const scratch = await mkdtemp(join(tmpdir(), "vault-stage9-mutations-"));
+const scratch = await mkdtemp(join(tmpdir(), "vault-search-mutations-"));
 const cases = [
   {
     id: "A", name: "MCP token authenticates sync", file: "src/server.ts",
@@ -22,7 +22,7 @@ const cases = [
     to: "inputSchema: z.strictObject({ vaultId: z.string().optional() }),",
     extra: [
       '() => executeTool(logger, "vault_status", () => service.vaultStatus()),',
-      '(input) => executeTool(logger, "vault_status", () => new VaultMcpService(storage, input.vaultId ?? config.vaultId, new SqliteSemanticSearch(storage, provider)).vaultStatus()),',
+      '(input) => executeTool(logger, "vault_status", () => new VaultMcpService(storage, input.vaultId ?? config.vaultId, new SemanticSearchService(storage, provider)).vaultStatus()),',
     ],
     test: "mcpProtocol", pattern: "rejects caller-selected vault scope",
   },
@@ -51,11 +51,11 @@ const cases = [
   },
   {
     id: "G", name: "raw vectors returned", file: "src/mcp/semanticSearch.ts",
-    from: "path: record.path,", to: "embedding: Array.from(record.vector),\n      path: record.path,",
+    from: "path: record.path,", to: "embedding: [1, 0, 0],\n      path: record.path,",
     test: "mcpSemanticSearch", pattern: "keeps only top K and returns no raw vectors",
   },
   {
-    id: "H", name: "result cap removed", file: "src/mcp/semanticSearch.ts",
+    id: "H", name: "result cap removed", file: "src/search/sqliteVectorBackend.ts",
     from: "if (ranked.length > limit) ranked.length = limit;", to: "// mutation: unbounded results",
     test: "mcpSemanticSearch", pattern: "keeps only top K and returns no raw vectors",
   },
@@ -70,6 +70,65 @@ const cases = [
     from: 'if (reportedModel === descriptor.model) return true;',
     to: 'if (descriptor.providerId === "openrouter" || reportedModel === descriptor.model) return true;',
     test: "queryEmbedding", pattern: "rejects a different OpenRouter response model despite identical dimensions",
+  },
+  {
+    id: "10-A", name: "Qdrant error propagates instead of SQLite fallback", file: "src/mcp/semanticSearch.ts",
+    from: "this.accelerator.invalidate();", to: 'throw new Error("QDRANT_UNAVAILABLE");',
+    test: "qdrantBackend", pattern: "Qdrant search failure falls back using exactly one query embedding",
+  },
+  {
+    id: "10-B", name: "fallback embeds query twice", file: "src/mcp/semanticSearch.ts",
+    from: "this.accelerator.invalidate();", to: "this.accelerator.invalidate(); await this.provider.embedQuery(descriptor, query);",
+    test: "qdrantBackend", pattern: "Qdrant search failure falls back using exactly one query embedding",
+  },
+  {
+    id: "10-C", name: "stale generation trusted as READY", file: "src/search/vectorBackend.ts",
+    from: "left.generation === right.generation &&", to: "",
+    test: "qdrantBackend", pattern: "requires exact generation, revision, vault and semantic space",
+  },
+  {
+    id: "10-D", name: "descriptor mismatch accepted", file: "src/search/vectorBackend.ts",
+    from: "&& sameSpace(left.descriptor, right.descriptor)", to: "",
+    test: "qdrantBackend", pattern: "requires exact generation, revision, vault and semantic space",
+  },
+  {
+    id: "10-E", name: "derived update notified before authoritative COMMIT", file: "src/storage/sqliteCompanionStorage.ts",
+    from: 'database.exec("COMMIT");',
+    to: 'this.publishCommit({ vaultId, generation: batch.generation, previousRevision: current?.revision ?? 0, revision, replaceVault: batch.replaceVault ?? false, paths }); database.exec("COMMIT");',
+    test: "qdrantBackend", pattern: "independent SQLite reader sees COMMIT before observers",
+  },
+  {
+    id: "10-F", name: "secondary failure breaks successful SQLite sync", file: "src/storage/sqliteCompanionStorage.ts",
+    from: "catch { /* Secondary work is isolated. */ }", to: "catch (error) { throw error; }",
+    test: "qdrantBackend", pattern: "observer failure cannot make a successful SQLite sync fail",
+  },
+  {
+    id: "10-G", name: "old collection queried after descriptor replacement", file: "src/search/qdrantBackend.ts",
+    from: 'this.pending = this.state === "READY"', to: 'if (notice.replaceVault) return; this.pending = this.state === "READY"',
+    extra: ["sameSnapshot(this.ready.snapshot, snapshot)", "snapshot.vaultId === this.vaultId"],
+    test: "qdrantBackend", pattern: "descriptor replacement never queries old space",
+  },
+  {
+    id: "10-H", name: "Qdrant key leaked through diagnostic status", file: "src/search/qdrantBackend.ts",
+    from: "lastErrorCode: this.lastErrorCode,", to: "lastErrorCode: this.config.apiKey,",
+    test: "qdrantBackend", pattern: "safe diagnostic status never includes Qdrant key",
+  },
+  {
+    id: "10-I", name: "full Markdown in point payload", file: "src/search/qdrantIndex.ts",
+    from: "chunkId: record.chunkId, vaultId: spec.vaultId,", to: 'markdown: "# PRIVATE MARKDOWN", chunkId: record.chunkId, vaultId: spec.vaultId,',
+    test: "qdrantIndex", pattern: "point payload has only retrieval identity and never full Markdown",
+  },
+  {
+    id: "10-J", name: "partial build published READY", file: "src/search/qdrantBackend.ts",
+    from: 'this.state = "BUILDING";',
+    to: 'this.state = "READY"; this.ready = { snapshot, spec: indexSpec(this.config.collectionPrefix, snapshot, "partial") };',
+    test: "qdrantBackend", pattern: "BUILDING never publishes a partial index",
+  },
+  {
+    id: "10-K", name: "missing authoritative chunk returned as derived content", file: "src/mcp/semanticSearch.ts",
+    from: "const record = chunks.get(chunkId);",
+    to: 'const record = chunks.get(chunkId) ?? { chunkId, path: "stale.md", ordinal: 0, headingPath: [], source: { startOffset: 0, endOffset: 0, startLine: 0, endLine: 0 }, text: "stale derived text" };',
+    test: "qdrantBackend", pattern: "missing SQLite hydration discards all Qdrant candidates",
   },
 ];
 

--- a/companion/src/config.ts
+++ b/companion/src/config.ts
@@ -13,6 +13,15 @@ export interface McpConfig {
   allowedHosts?: string[];
 }
 
+export interface QdrantConfig {
+  enabled: boolean;
+  url: string;
+  apiKey: string;
+  timeoutMs: number;
+  collectionPrefix: string;
+  allowInsecureRemoteHttp: boolean;
+}
+
 export interface CompanionConfig {
   host: string;
   port: number;
@@ -22,6 +31,7 @@ export interface CompanionConfig {
   logLevel: LogLevel;
   bodyLimitBytes: number;
   mcp: McpConfig;
+  qdrant?: QdrantConfig;
 }
 
 export class ConfigurationError extends Error {
@@ -74,6 +84,37 @@ export function isLoopbackHost(host: string): boolean {
   return false;
 }
 
+export function loadQdrantConfig(environment: NodeJS.ProcessEnv): QdrantConfig {
+  const enabled = booleanValue(environment.QDRANT_ENABLED, false, "QDRANT_ENABLED");
+  const allowInsecureRemoteHttp = booleanValue(
+    environment.QDRANT_ALLOW_INSECURE_REMOTE_HTTP, false, "QDRANT_ALLOW_INSECURE_REMOTE_HTTP",
+  );
+  let url: URL;
+  try {
+    url = new URL(environment.QDRANT_URL?.trim() || "http://127.0.0.1:6333");
+    if (!["http:", "https:"].includes(url.protocol) || url.username || url.password || url.search || url.hash) {
+      throw new Error();
+    }
+  } catch {
+    throw new ConfigurationError("QDRANT_URL must be an HTTP(S) URL without credentials, query, or fragment.");
+  }
+  if (url.protocol === "http:" && !isLoopbackHost(url.hostname.replace(/^\[|\]$/gu, "")) && !allowInsecureRemoteHttp) {
+    throw new ConfigurationError("Non-loopback QDRANT_URL HTTP requires QDRANT_ALLOW_INSECURE_REMOTE_HTTP=true.");
+  }
+  const collectionPrefix = environment.QDRANT_COLLECTION_PREFIX?.trim() || "vault_audit";
+  if (!/^[a-zA-Z0-9_]{1,32}$/u.test(collectionPrefix)) {
+    throw new ConfigurationError("QDRANT_COLLECTION_PREFIX must contain 1 to 32 letters, digits, or underscores.");
+  }
+  const apiKey = environment.QDRANT_API_KEY?.trim() ?? "";
+  if (!/^[\x20-\x7E]*$/u.test(apiKey)) throw new ConfigurationError("QDRANT_API_KEY must contain printable ASCII characters.");
+  return {
+    enabled, url: url.toString().replace(/\/$/u, ""),
+    apiKey,
+    timeoutMs: positiveInteger(environment.QDRANT_TIMEOUT_MS, 5000, "QDRANT_TIMEOUT_MS", 100, 120_000),
+    collectionPrefix, allowInsecureRemoteHttp,
+  };
+}
+
 export function loadConfig(environment: NodeJS.ProcessEnv = process.env): CompanionConfig {
   const host = environment.HOST?.trim() || "127.0.0.1";
   if (!validHostname(host)) throw new ConfigurationError("HOST must be a valid IP address or hostname.");
@@ -110,6 +151,8 @@ export function loadConfig(environment: NodeJS.ProcessEnv = process.env): Compan
   if (allowedHosts.length === 0 || allowedHosts.some((value) => !validHostname(value.replace(/^\[|\]$/gu, "")))) {
     throw new ConfigurationError("MCP_ALLOWED_HOSTS must contain explicit hostnames or IP addresses, without schemes or ports.");
   }
+  const qdrant = loadQdrantConfig(environment);
+  if (qdrant.enabled && !mcpVaultId) throw new ConfigurationError("MCP_VAULT_ID is required when QDRANT_ENABLED=true.");
   return {
     host,
     port,
@@ -118,6 +161,7 @@ export function loadConfig(environment: NodeJS.ProcessEnv = process.env): Compan
     allowRemoteBind,
     logLevel: level as LogLevel,
     bodyLimitBytes: 16 * 1024 * 1024,
+    qdrant,
     mcp: {
       enabled: mcpEnabled,
       token: mcpToken,

--- a/companion/src/mcp/mcpServer.ts
+++ b/companion/src/mcp/mcpServer.ts
@@ -17,8 +17,10 @@ import {
   MAX_SEARCH_LIMIT,
   VaultMcpService,
 } from "./service.js";
-import { SqliteSemanticSearch } from "./semanticSearch.js";
+import { SemanticSearchService } from "./semanticSearch.js";
 import { MAX_CURSOR_LENGTH } from "./pagination.js";
+
+import type { DerivedVectorBackend } from "../search/vectorBackend.js";
 
 const dataTrustSchema = z.literal("untrusted-vault-data");
 const sourceSchema = z.strictObject({
@@ -111,8 +113,9 @@ export function createVaultMcpServer(
   config: McpConfig,
   logger: Logger,
   provider: QueryEmbeddingProvider,
+  backend?: DerivedVectorBackend,
 ): McpServer {
-  const service = new VaultMcpService(storage, config.vaultId, new SqliteSemanticSearch(storage, provider));
+  const service = new VaultMcpService(storage, config.vaultId, new SemanticSearchService(storage, provider, backend));
   const server = new McpServer({ name: "vault-audit-ai-companion", version: "0.1.0" }, {
     capabilities: { tools: { listChanged: false } },
   });
@@ -228,9 +231,10 @@ export function createVaultMcpHandler(
     apiKey: config.embeddingApiKey,
     timeoutMs: config.embeddingTimeoutMs,
   }),
+  backend?: DerivedVectorBackend,
 ): McpHttpHandler {
   return createMcpHandler(
-    () => createVaultMcpServer(storage, config, logger, provider),
+    () => createVaultMcpServer(storage, config, logger, provider, backend),
     {
       legacy: "stateless",
       responseMode: "auto",

--- a/companion/src/mcp/semanticSearch.ts
+++ b/companion/src/mcp/semanticSearch.ts
@@ -1,12 +1,13 @@
-import type { SemanticDescriptor } from "../protocol/types.js";
-import type { McpReadStorage, McpStoredVector } from "../storage/mcpReadStorage.js";
+import type { McpReadStorage, SearchSnapshot } from "../storage/mcpReadStorage.js";
 import { assertCompatibleDescriptor } from "./descriptor.js";
 import { boundedHeadings } from "./bounds.js";
 import { semanticSearchUnavailable } from "./errors.js";
 import type { QueryEmbeddingProvider } from "./queryEmbedding.js";
+import { normalizeQuery } from "../search/vectorMath.js";
+import { SQLiteVectorBackend } from "../search/sqliteVectorBackend.js";
+import { compareCandidates, sameSnapshot, sameSpace } from "../search/vectorBackend.js";
+import type { DerivedVectorBackend, SearchContext, VectorCandidate } from "../search/vectorBackend.js";
 
-const MIN_VECTOR_NORM = 1e-12;
-const STORED_UNIT_NORM_TOLERANCE = 1e-4;
 export const MAX_SEARCH_TEXT_CODE_POINTS = 4000;
 
 export interface McpSearchResult {
@@ -28,46 +29,6 @@ export interface McpSearchResult {
   textTruncated: boolean;
 }
 
-interface RankedVector {
-  record: McpStoredVector;
-  score: number;
-}
-
-function compareRank(left: RankedVector, right: RankedVector): number {
-  if (right.score !== left.score) return right.score - left.score;
-  return left.record.chunkId < right.record.chunkId ? -1 : left.record.chunkId > right.record.chunkId ? 1 : 0;
-}
-
-function vectorNorm(vector: Float32Array): number {
-  let squared = 0;
-  for (let index = 0; index < vector.length; index++) {
-    const value = vector[index] ?? Number.NaN;
-    if (!Number.isFinite(value)) throw semanticSearchUnavailable();
-    squared += value * value;
-  }
-  const norm = Math.sqrt(squared);
-  if (!Number.isFinite(norm) || norm <= MIN_VECTOR_NORM) throw semanticSearchUnavailable();
-  return norm;
-}
-
-function normalizeQuery(vector: Float32Array, dimensions: number): Float32Array {
-  if (vector.length !== dimensions) throw semanticSearchUnavailable();
-  const norm = vectorNorm(vector);
-  const result = new Float32Array(dimensions);
-  for (let index = 0; index < dimensions; index++) result[index] = (vector[index] ?? 0) / norm;
-  return result;
-}
-
-function scoreVector(stored: Float32Array, query: Float32Array): number {
-  if (stored.length !== query.length) throw semanticSearchUnavailable();
-  const norm = vectorNorm(stored);
-  if (Math.abs(norm - 1) > STORED_UNIT_NORM_TOLERANCE) throw semanticSearchUnavailable();
-  let score = 0;
-  for (let index = 0; index < stored.length; index++) score += (stored[index] ?? 0) * (query[index] ?? 0);
-  if (!Number.isFinite(score)) throw semanticSearchUnavailable();
-  return Math.max(-1, Math.min(1, score));
-}
-
 function boundedText(text: string): { text: string; totalTextChars: number; textTruncated: boolean } {
   const codePoints = Array.from(text);
   return {
@@ -77,53 +38,79 @@ function boundedText(text: string): { text: string; totalTextChars: number; text
   };
 }
 
-export class SqliteSemanticSearch {
+export class SemanticSearchService {
+  private readonly sqlite: SQLiteVectorBackend;
+
   constructor(
     private readonly storage: McpReadStorage,
     private readonly provider: QueryEmbeddingProvider,
-  ) {}
+    private readonly accelerator?: DerivedVectorBackend,
+  ) {
+    this.sqlite = new SQLiteVectorBackend(storage);
+  }
 
   async search(vaultId: string, query: string, limit: number): Promise<McpSearchResult[]> {
-    const status = await this.storage.getMcpVaultStatus(vaultId);
+    const status = await this.storage.getSearchSnapshot(vaultId);
     if (!status.exists || status.chunkCount === 0) return [];
-    const descriptor: SemanticDescriptor | null = status.descriptor;
+    const descriptor = status.descriptor;
     if (!descriptor) throw semanticSearchUnavailable();
     assertCompatibleDescriptor(descriptor);
-
     let queryVector: Float32Array;
     try {
       queryVector = normalizeQuery(await this.provider.embedQuery(descriptor, query), descriptor.dimensions);
     } catch {
       throw semanticSearchUnavailable();
     }
-
-    // A sync may commit while the provider request is in flight. Never use its
-    // query vector with a replacement space, or return a mixed generation.
-    const afterEmbedding = await this.storage.getMcpVaultStatus(vaultId);
-    if (JSON.stringify(afterEmbedding) !== JSON.stringify(status)) throw semanticSearchUnavailable();
-
-    const ranked: RankedVector[] = [];
-    try {
-      for (const record of this.storage.iterateMcpVectors(vaultId, descriptor.dimensions)) {
-        ranked.push({ record, score: scoreVector(record.vector, queryVector) });
-        ranked.sort(compareRank);
-        if (ranked.length > limit) ranked.length = limit;
+    const afterEmbedding = await this.storage.getSearchSnapshot(vaultId);
+    if (!sameSnapshot(afterEmbedding, status)) throw semanticSearchUnavailable();
+    const context: SearchContext = { snapshot: status, queryVector };
+    if (this.accelerator?.available(status)) {
+      try {
+        const candidates = await this.accelerator.search(context, limit);
+        const results = await this.hydrate(status, candidates, limit);
+        if (!this.accelerator.available(status)) throw semanticSearchUnavailable();
+        this.accelerator.recordBackend("qdrant");
+        return results;
+      } catch {
+        this.accelerator.invalidate();
+        // Fallback always reuses the already normalized query vector.
       }
+    }
+    try {
+      const current = await this.storage.getSearchSnapshot(vaultId);
+      if (!sameSpace(current.descriptor, descriptor)) throw semanticSearchUnavailable();
+      const candidates = await this.sqlite.search({ snapshot: current, queryVector }, limit);
+      const results = await this.hydrate(current, candidates, limit);
+      this.accelerator?.recordBackend("sqlite");
+      return results;
     } catch {
       throw semanticSearchUnavailable();
     }
-    const texts = await this.storage.getMcpChunkTexts(vaultId, ranked.map((item) => item.record.chunkId));
-    if (JSON.stringify(await this.storage.getMcpVaultStatus(vaultId)) !== JSON.stringify(status)) {
+  }
+
+  private async hydrate(snapshot: SearchSnapshot, candidates: VectorCandidate[], limit: number): Promise<McpSearchResult[]> {
+    if (new Set(candidates.map((item) => item.chunkId)).size !== candidates.length || candidates.length !== Math.min(limit, snapshot.chunkCount)) {
       throw semanticSearchUnavailable();
     }
-    return ranked.map(({ record, score }) => ({
-      path: record.path,
-      chunkId: record.chunkId,
-      ordinal: record.ordinal,
-      ...boundedHeadings(record.headingPath),
-      source: { ...record.source },
-      score,
-      ...boundedText(texts.get(record.chunkId) ?? ""),
-    }));
+    const chunks = await this.storage.getSearchChunks(snapshot.vaultId, candidates.map((item) => item.chunkId));
+    if (!sameSnapshot(await this.storage.getSearchSnapshot(snapshot.vaultId), snapshot)) throw semanticSearchUnavailable();
+    return candidates.sort(compareCandidates).map(({ chunkId, score }) => {
+      const record = chunks.get(chunkId);
+      if (!record || !Number.isFinite(score) || score < -1 || score > 1) throw semanticSearchUnavailable();
+      return {
+        path: record.path,
+        chunkId: record.chunkId,
+        ordinal: record.ordinal,
+        ...boundedHeadings(record.headingPath),
+        source: { ...record.source },
+        score,
+        ...boundedText(record.text),
+      };
+    });
   }
+}
+
+/** Kept as an independently testable, permanent SQLite-only entry point. */
+export class SqliteSemanticSearch extends SemanticSearchService {
+  constructor(storage: McpReadStorage, provider: QueryEmbeddingProvider) { super(storage, provider); }
 }

--- a/companion/src/mcp/service.ts
+++ b/companion/src/mcp/service.ts
@@ -5,7 +5,7 @@ import { McpToolError } from "./errors.js";
 import { boundedHeadings } from "./bounds.js";
 import { chunksCursor, notesCursor, parseChunksCursor, parseNotesCursor } from "./pagination.js";
 import type { McpSearchResult } from "./semanticSearch.js";
-import { SqliteSemanticSearch } from "./semanticSearch.js";
+import type { SemanticSearchService } from "./semanticSearch.js";
 
 export const DEFAULT_LIST_LIMIT = 50;
 export const MAX_LIST_LIMIT = 200;
@@ -66,12 +66,12 @@ export interface VaultStatusOutput {
 }
 
 export class VaultMcpService {
-  private readonly semanticSearch: SqliteSemanticSearch;
+  private readonly semanticSearch: SemanticSearchService;
 
   constructor(
     private readonly storage: McpReadStorage,
     private readonly vaultId: string,
-    semanticSearch: SqliteSemanticSearch,
+    semanticSearch: SemanticSearchService,
   ) {
     this.semanticSearch = semanticSearch;
   }

--- a/companion/src/search/qdrantBackend.ts
+++ b/companion/src/search/qdrantBackend.ts
@@ -1,0 +1,175 @@
+import { randomUUID } from "node:crypto";
+import type { QdrantConfig } from "../config.js";
+import { assertCompatibleDescriptor } from "../mcp/descriptor.js";
+import type { CommitNotice } from "../storage/companionStorage.js";
+import type { McpReadStorage, SearchSnapshot } from "../storage/mcpReadStorage.js";
+import { indexPoint, indexSpec, QDRANT_BATCH_SIZE, QdrantIndexError } from "./qdrantIndex.js";
+import type { IndexSpec, QdrantVectorIndex } from "./qdrantIndex.js";
+import { sameSnapshot } from "./vectorBackend.js";
+import type { DerivedVectorBackend, SearchContext, VectorCandidate } from "./vectorBackend.js";
+
+export type QdrantState = "DISABLED" | "BUILDING" | "READY" | "STALE" | "ERROR";
+
+export interface QdrantStatus {
+  enabled: boolean; state: QdrantState; connected: boolean; collection: string | null; vaultId: string;
+  embeddingSpaceId: string | null; indexedGeneration: number | null; currentGeneration: number;
+  indexedRevision: number | null; currentRevision: number; lastErrorCode: string | null;
+  lastSuccessfulSyncAt: string | null; lastSearchBackend: "sqlite" | "qdrant" | null;
+}
+
+/** One configured Vault, one worker and at most one pending incremental change. */
+export class QdrantVectorBackend implements DerivedVectorBackend {
+  private state: QdrantState;
+  private ready: { snapshot: SearchSnapshot; spec: IndexSpec } | null = null;
+  private connected = false;
+  private lastErrorCode: string | null = null;
+  private lastSuccessfulSyncAt: string | null = null;
+  private lastSearchBackend: "sqlite" | "qdrant" | null = null;
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private running: Promise<void> | null = null;
+  private closed = false;
+  private pending: CommitNotice | null = null;
+  private epoch = 0;
+  private failures = 0;
+
+  constructor(private readonly storage: McpReadStorage, private readonly vaultId: string,
+    private readonly config: QdrantConfig, private readonly index: QdrantVectorIndex) {
+    this.state = config.enabled ? "STALE" : "DISABLED";
+  }
+  start(): void { if (this.config.enabled) this.schedule(0); }
+  private schedule(delay: number): void {
+    if (this.closed || !this.config.enabled || this.timer) return;
+    this.timer = setTimeout(() => { this.timer = null; void this.reconcile(); }, delay);
+    this.timer.unref();
+  }
+  onCommit(notice: CommitNotice): void {
+    if (!this.config.enabled || notice.vaultId !== this.vaultId || this.closed) return;
+    this.pending = this.state === "READY" && !this.running && !notice.replaceVault &&
+      notice.previousRevision === this.ready?.snapshot.revision ? notice : null;
+    this.epoch++;
+    this.state = "STALE";
+    if (this.timer) clearTimeout(this.timer);
+    this.timer = null;
+    this.schedule(0);
+  }
+  available(snapshot: SearchSnapshot): boolean {
+    return this.config.enabled && !this.closed && this.state === "READY" && this.ready !== null &&
+      sameSnapshot(this.ready.snapshot, snapshot);
+  }
+  invalidate(): void {
+    if (!this.config.enabled || this.closed) return;
+    this.epoch++;
+    this.state = "ERROR";
+    this.connected = false;
+    this.lastErrorCode = "QDRANT_INVALID_INDEX";
+    this.pending = null;
+    this.schedule(1000);
+  }
+  recordBackend(backend: "sqlite" | "qdrant"): void { this.lastSearchBackend = backend; }
+  async status(): Promise<QdrantStatus> {
+    const current = await this.storage.getSearchSnapshot(this.vaultId);
+    const state = this.state === "READY" && !this.available(current) ? "STALE" : this.state;
+    return {
+      enabled: this.config.enabled, state, connected: this.connected,
+      collection: this.ready?.spec.collection ?? null, vaultId: this.vaultId,
+      embeddingSpaceId: this.ready?.snapshot.descriptor?.embeddingSpaceId ?? null,
+      indexedGeneration: this.ready?.snapshot.generation ?? null, currentGeneration: current.generation,
+      indexedRevision: this.ready?.snapshot.revision ?? null, currentRevision: current.revision,
+      lastErrorCode: this.lastErrorCode, lastSuccessfulSyncAt: this.lastSuccessfulSyncAt,
+      lastSearchBackend: this.lastSearchBackend,
+    };
+  }
+  async search(context: SearchContext, limit: number): Promise<VectorCandidate[]> {
+    if (!this.available(context.snapshot) || !this.ready) throw new QdrantIndexError();
+    const epoch = this.epoch;
+    const results = await this.index.search(this.ready.spec, context.queryVector, limit);
+    if (epoch !== this.epoch || !this.available(context.snapshot)) throw new QdrantIndexError();
+    return results;
+  }
+  reconcile(): Promise<void> {
+    if (this.running) return this.running;
+    if (this.closed || !this.config.enabled) return Promise.resolve();
+    if (this.timer) clearTimeout(this.timer);
+    this.timer = null;
+    this.running = this.run().finally(() => {
+      this.running = null;
+      // Bounded periodic reconciliation, no retained failure history or retry loop.
+      this.schedule(this.state === "READY" ? 30_000 : Math.min(30_000, 1000 * 2 ** Math.min(this.failures, 5)));
+    });
+    return this.running;
+  }
+  private async assertCurrent(snapshot: SearchSnapshot, epoch: number): Promise<void> {
+    if (this.closed || epoch !== this.epoch || !sameSnapshot(await this.storage.getSearchSnapshot(this.vaultId), snapshot)) {
+      throw new QdrantIndexError();
+    }
+  }
+  private async upload(spec: IndexSpec, snapshot: SearchSnapshot, epoch: number, paths?: readonly string[]): Promise<number> {
+    let after = "";
+    let uploaded = 0;
+    for (;;) {
+      await this.assertCurrent(snapshot, epoch);
+      const page = this.storage.listVectorPage(this.vaultId, spec.dimensions, after, QDRANT_BATCH_SIZE, paths);
+      if (page.length === 0) break;
+      await this.index.upsert(spec, page.map((record) => indexPoint(spec, record)));
+      uploaded += page.length;
+      after = page.at(-1)!.chunkId;
+    }
+    return uploaded;
+  }
+  private async run(): Promise<void> {
+    const epoch = this.epoch;
+    const change = this.pending;
+    this.pending = null;
+    try {
+      const snapshot = await this.storage.getSearchSnapshot(this.vaultId);
+      if (!snapshot.descriptor) { this.state = "STALE"; return; }
+      assertCompatibleDescriptor(snapshot.descriptor);
+      if (this.available(snapshot) && this.ready) {
+        await this.index.verify(this.ready.spec);
+        await this.assertCurrent(snapshot, epoch);
+        this.connected = true;
+        return;
+      }
+      this.state = "BUILDING";
+      const spec = indexSpec(this.config.collectionPrefix, snapshot, randomUUID());
+      await this.index.ensureCollection(spec);
+      await this.assertCurrent(snapshot, epoch);
+      if (change && this.ready && change.revision === snapshot.revision &&
+          this.ready.spec.collection === spec.collection && change.previousRevision === this.ready.snapshot.revision) {
+        await this.index.verify(this.ready.spec);
+        for (let offset = 0; offset < change.paths.length; offset += QDRANT_BATCH_SIZE) {
+          await this.assertCurrent(snapshot, epoch);
+          const paths = change.paths.slice(offset, offset + QDRANT_BATCH_SIZE);
+          await this.index.deleteNotes(spec, paths);
+          await this.upload(spec, snapshot, epoch, paths);
+        }
+        await this.index.stamp(spec);
+      } else {
+        await this.index.clear(spec);
+        const uploaded = await this.upload(spec, snapshot, epoch);
+        if (uploaded !== snapshot.chunkCount) throw new QdrantIndexError();
+      }
+      await this.index.verify(spec);
+      await this.assertCurrent(snapshot, epoch);
+      this.ready = { snapshot, spec };
+      this.state = "READY";
+      this.connected = true;
+      this.lastErrorCode = null;
+      this.lastSuccessfulSyncAt = new Date().toISOString();
+      this.failures = 0;
+    } catch (error) {
+      this.state = epoch === this.epoch ? "ERROR" : "STALE";
+      this.connected = false;
+      this.lastErrorCode = error instanceof QdrantIndexError ? error.code : "QDRANT_INVALID_INDEX";
+      this.failures = Math.min(this.failures + 1, 5);
+      this.pending = null;
+    }
+  }
+  close(): void {
+    this.closed = true;
+    this.epoch++;
+    if (this.timer) clearTimeout(this.timer);
+    this.timer = null;
+    this.index.close();
+  }
+}

--- a/companion/src/search/qdrantIndex.ts
+++ b/companion/src/search/qdrantIndex.ts
@@ -1,0 +1,194 @@
+import { createHash } from "node:crypto";
+import { QdrantClient } from "@qdrant/js-client-rest";
+import type { QdrantConfig } from "../config.js";
+import type { McpStoredVector, SearchSnapshot } from "../storage/mcpReadStorage.js";
+import { compareCandidates } from "./vectorBackend.js";
+import type { VectorCandidate } from "./vectorBackend.js";
+import { scoreVector } from "./vectorMath.js";
+
+export const QDRANT_BATCH_SIZE = 128;
+const MAX_CANDIDATES = 256;
+export function identityHash(value: string): string { return createHash("sha256").update(value).digest("hex"); }
+export function collectionName(prefix: string, vaultId: string, embeddingSpaceId: string): string {
+  return `${prefix}_${identityHash(vaultId).slice(0, 32)}_${identityHash(embeddingSpaceId).slice(0, 32)}`;
+}
+export function pointId(vaultId: string, chunkId: string): string {
+  const hash = identityHash(JSON.stringify([vaultId, chunkId])).slice(0, 32).split("");
+  hash[12] = "8";
+  hash[16] = ((Number.parseInt(hash[16]!, 16) & 3) | 8).toString(16);
+  const hex = hash.join("");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+export class QdrantIndexError extends Error {
+  constructor(readonly code: "QDRANT_UNAVAILABLE" | "QDRANT_INVALID_INDEX" = "QDRANT_INVALID_INDEX") {
+    super(code);
+    this.name = "QdrantIndexError";
+  }
+}
+export interface IndexSpec {
+  collection: string;
+  owner: string;
+  vaultId: string;
+  embeddingSpaceId: string;
+  dimensions: number;
+  generation: number;
+  revision: number;
+  buildId: string;
+  count: number;
+}
+export interface IndexPoint {
+  id: string;
+  vector: number[];
+  payload: {
+    chunkId: string; vaultId: string; embeddingSpaceId: string; generation: number;
+    revision: number; buildId: string; noteKey: string;
+  };
+}
+export function indexSpec(prefix: string, snapshot: SearchSnapshot, buildId: string): IndexSpec {
+  const descriptor = snapshot.descriptor;
+  if (!descriptor) throw new QdrantIndexError();
+  return {
+    collection: collectionName(prefix, snapshot.vaultId, descriptor.embeddingSpaceId),
+    owner: identityHash(JSON.stringify(["vault-audit-ai:1", snapshot.vaultId, descriptor.embeddingSpaceId])),
+    vaultId: snapshot.vaultId, embeddingSpaceId: descriptor.embeddingSpaceId, dimensions: descriptor.dimensions,
+    generation: snapshot.generation, revision: snapshot.revision, buildId, count: snapshot.chunkCount,
+  };
+}
+export function indexPoint(spec: IndexSpec, record: McpStoredVector): IndexPoint {
+  if (record.vector.length !== spec.dimensions) throw new QdrantIndexError();
+  scoreVector(record.vector, record.vector); // Validate finite, unit-length stored vectors without modifying them.
+  return {
+    id: pointId(spec.vaultId, record.chunkId), vector: Array.from(record.vector),
+    payload: {
+      chunkId: record.chunkId, vaultId: spec.vaultId, embeddingSpaceId: spec.embeddingSpaceId,
+      generation: spec.generation, revision: spec.revision, buildId: spec.buildId,
+      noteKey: identityHash(record.path),
+    },
+  };
+}
+export interface QdrantVectorIndex {
+  ensureCollection(spec: IndexSpec): Promise<void>;
+  clear(spec: IndexSpec): Promise<void>;
+  upsert(spec: IndexSpec, points: IndexPoint[]): Promise<void>;
+  deleteNotes(spec: IndexSpec, paths: readonly string[]): Promise<void>;
+  stamp(spec: IndexSpec): Promise<void>;
+  verify(spec: IndexSpec): Promise<void>;
+  search(spec: IndexSpec, vector: Float32Array, limit: number): Promise<VectorCandidate[]>;
+  close(): void;
+}
+function stampPayload(spec: IndexSpec): Pick<IndexPoint["payload"], "vaultId" | "embeddingSpaceId" | "generation" | "revision" | "buildId"> {
+  return { vaultId: spec.vaultId, embeddingSpaceId: spec.embeddingSpaceId,
+    generation: spec.generation, revision: spec.revision, buildId: spec.buildId };
+}
+function currentFilter(spec: IndexSpec): { must: Array<{ key: string; match: { value: string | number } }> } {
+  return { must: Object.entries(stampPayload(spec)).map(([key, value]) => ({ key, match: { value } })) };
+}
+const REQUEST_OPTIONS = { redirect: "error" } as const;
+
+/** Official generated SDK operations allow redirect refusal on every request. */
+export class QdrantClientIndex implements QdrantVectorIndex {
+  private readonly api: ReturnType<QdrantClient["api"]>;
+  private closed = false;
+  constructor(config: QdrantConfig) {
+    try {
+      const url = new URL(config.url);
+      this.api = new QdrantClient({
+      url: url.origin, prefix: url.pathname === "/" ? "" : url.pathname, port: null,
+      timeout: config.timeoutMs, maxConnections: 4, checkCompatibility: false,
+      headers: config.apiKey ? { "api-key": config.apiKey } : {},
+      }).api();
+    } catch { throw new QdrantIndexError("QDRANT_UNAVAILABLE"); }
+  }
+  private async request<T>(operation: () => Promise<T>): Promise<T> {
+    if (this.closed) throw new QdrantIndexError("QDRANT_UNAVAILABLE");
+    try { return await operation(); } catch (error) {
+      if (error instanceof QdrantIndexError) throw error;
+      // Never retain upstream messages, response bodies, URLs, headers or causes.
+      throw new QdrantIndexError("QDRANT_UNAVAILABLE");
+    }
+  }
+  async ensureCollection(spec: IndexSpec): Promise<void> {
+    await this.request(async () => {
+      const exists = await this.api.collectionExists({ collection_name: spec.collection }, REQUEST_OPTIONS);
+      if (exists.data.result?.exists === false) {
+        const created = await this.api.createCollection({
+          collection_name: spec.collection, vectors: { size: spec.dimensions, distance: "Cosine" },
+          metadata: { vaultAuditOwner: spec.owner },
+        }, REQUEST_OPTIONS);
+        if (created.data.result !== true) throw new QdrantIndexError();
+      } else if (exists.data.result?.exists !== true) throw new QdrantIndexError();
+      await this.checkCollection(spec);
+    });
+  }
+  private async checkCollection(spec: IndexSpec): Promise<void> {
+    const result = (await this.api.getCollection({ collection_name: spec.collection }, REQUEST_OPTIONS)).data.result;
+    const vectors = result?.config.params.vectors;
+    if (!result || result.status === "red" || result.config.metadata?.vaultAuditOwner !== spec.owner ||
+        !vectors || vectors.size !== spec.dimensions || vectors.distance !== "Cosine") throw new QdrantIndexError();
+  }
+  private completed(value: unknown): void {
+    if (!value || typeof value !== "object" || !("status" in value) || value.status !== "completed") {
+      throw new QdrantIndexError();
+    }
+  }
+  async clear(spec: IndexSpec): Promise<void> {
+    await this.request(async () => {
+      await this.checkCollection(spec); // Never clear a foreign or incompatible collection.
+      this.completed((await this.api.deletePoints({ collection_name: spec.collection, wait: true, filter: {} }, REQUEST_OPTIONS)).data.result);
+    });
+  }
+  async upsert(spec: IndexSpec, points: IndexPoint[]): Promise<void> {
+    await this.request(async () => {
+      if (points.length > QDRANT_BATCH_SIZE || points.some((point) => point.vector.length !== spec.dimensions)) throw new QdrantIndexError();
+      this.completed((await this.api.upsertPoints({ collection_name: spec.collection, wait: true, points }, REQUEST_OPTIONS)).data.result);
+    });
+  }
+  async deleteNotes(spec: IndexSpec, paths: readonly string[]): Promise<void> {
+    await this.request(async () => {
+      if (paths.length > QDRANT_BATCH_SIZE) throw new QdrantIndexError();
+      this.completed((await this.api.deletePoints({ collection_name: spec.collection, wait: true,
+        filter: { must: [{ key: "noteKey", match: { any: paths.map(identityHash) } }] },
+      }, REQUEST_OPTIONS)).data.result);
+    });
+  }
+  async stamp(spec: IndexSpec): Promise<void> {
+    await this.request(async () => {
+      this.completed((await this.api.setPayload({ collection_name: spec.collection, wait: true,
+        filter: {}, payload: stampPayload(spec),
+      }, REQUEST_OPTIONS)).data.result);
+    });
+  }
+  async verify(spec: IndexSpec): Promise<void> {
+    await this.request(async () => {
+      await this.checkCollection(spec);
+      const all = await this.api.countPoints({ collection_name: spec.collection, exact: true }, REQUEST_OPTIONS);
+      const current = await this.api.countPoints({ collection_name: spec.collection, exact: true, filter: currentFilter(spec) }, REQUEST_OPTIONS);
+      if (all.data.result?.count !== spec.count || current.data.result?.count !== spec.count) throw new QdrantIndexError();
+    });
+  }
+  async search(spec: IndexSpec, vector: Float32Array, limit: number): Promise<VectorCandidate[]> {
+    return this.request(async () => {
+      await this.verify(spec); // Detect offline, missing, empty, restored or partially deleted indexes.
+      if (vector.length !== spec.dimensions || !Array.from(vector).every(Number.isFinite)) throw new QdrantIndexError();
+      const requested = Math.min(spec.count, Math.min(MAX_CANDIDATES, Math.max(64, limit * 4)) + 1);
+      const response = await this.api.queryPoints({
+        collection_name: spec.collection, query: Array.from(vector), filter: currentFilter(spec),
+        limit: requested, with_payload: true, with_vector: false,
+      }, REQUEST_OPTIONS);
+      const points = response.data.result?.points;
+      if (!Array.isArray(points) || points.length !== requested) throw new QdrantIndexError();
+      const candidates = points.map((point) => {
+        const payload = point.payload;
+        if (!payload || typeof payload.chunkId !== "string" || point.id !== pointId(spec.vaultId, payload.chunkId) ||
+            Object.entries(stampPayload(spec)).some(([key, value]) => payload[key] !== value) ||
+            !Number.isFinite(point.score) || point.score < -1.000001 || point.score > 1.000001) throw new QdrantIndexError();
+        return { chunkId: payload.chunkId, score: Math.max(-1, Math.min(1, point.score)) };
+      }).sort(compareCandidates);
+      if (new Set(candidates.map((point) => point.chunkId)).size !== candidates.length) throw new QdrantIndexError();
+      // If the bounded candidate window cuts a tie, SQLite resolves the complete tie deterministically.
+      if (requested < spec.count && Math.abs(candidates[limit - 1]!.score - candidates.at(-1)!.score) <= 1e-6) throw new QdrantIndexError();
+      return candidates.slice(0, limit);
+    });
+  }
+  close(): void { this.closed = true; }
+}

--- a/companion/src/search/sqliteVectorBackend.ts
+++ b/companion/src/search/sqliteVectorBackend.ts
@@ -1,0 +1,19 @@
+import type { McpReadStorage } from "../storage/mcpReadStorage.js";
+import { semanticSearchUnavailable } from "../mcp/errors.js";
+import { scoreVector } from "./vectorMath.js";
+import { compareCandidates } from "./vectorBackend.js";
+import type { SearchContext, VectorCandidate, VectorSearchBackend } from "./vectorBackend.js";
+
+export class SQLiteVectorBackend implements VectorSearchBackend {
+  constructor(private readonly storage: McpReadStorage) {}
+  search({ snapshot, queryVector }: SearchContext, limit: number): Promise<VectorCandidate[]> {
+    if (!snapshot.descriptor) throw semanticSearchUnavailable();
+    const ranked: VectorCandidate[] = [];
+    for (const record of this.storage.iterateMcpVectors(snapshot.vaultId, snapshot.descriptor.dimensions)) {
+      ranked.push({ chunkId: record.chunkId, score: scoreVector(record.vector, queryVector) });
+      ranked.sort(compareCandidates);
+      if (ranked.length > limit) ranked.length = limit;
+    }
+    return Promise.resolve(ranked);
+  }
+}

--- a/companion/src/search/vectorBackend.ts
+++ b/companion/src/search/vectorBackend.ts
@@ -1,0 +1,24 @@
+import type { SemanticDescriptor } from "../protocol/types.js";
+import type { SearchSnapshot } from "../storage/mcpReadStorage.js";
+
+export interface VectorCandidate { chunkId: string; score: number }
+export interface SearchContext { snapshot: SearchSnapshot; queryVector: Float32Array }
+export interface VectorSearchBackend { search(context: SearchContext, limit: number): Promise<VectorCandidate[]> }
+export interface DerivedVectorBackend extends VectorSearchBackend {
+  available(snapshot: SearchSnapshot): boolean;
+  invalidate(): void;
+  recordBackend(backend: "sqlite" | "qdrant"): void;
+}
+export function compareCandidates(left: VectorCandidate, right: VectorCandidate): number {
+  if (right.score !== left.score) return right.score - left.score;
+  return left.chunkId < right.chunkId ? -1 : left.chunkId > right.chunkId ? 1 : 0;
+}
+export function sameSpace(left: SemanticDescriptor | null, right: SemanticDescriptor | null): boolean {
+  if (!left || !right) return left === right;
+  return left.providerId === right.providerId && left.model === right.model && left.baseUrl === right.baseUrl &&
+    left.dimensions === right.dimensions && left.embeddingSpaceId === right.embeddingSpaceId && left.normalized === right.normalized;
+}
+export function sameSnapshot(left: SearchSnapshot, right: SearchSnapshot): boolean {
+  return left.vaultId === right.vaultId && left.generation === right.generation && left.revision === right.revision &&
+    left.exists === right.exists && left.chunkCount === right.chunkCount && sameSpace(left.descriptor, right.descriptor);
+}

--- a/companion/src/search/vectorMath.ts
+++ b/companion/src/search/vectorMath.ts
@@ -1,0 +1,34 @@
+import { semanticSearchUnavailable } from "../mcp/errors.js";
+const MIN_VECTOR_NORM = 1e-12;
+const STORED_UNIT_NORM_TOLERANCE = 1e-4;
+
+function vectorNorm(vector: Float32Array): number {
+  let squared = 0;
+  for (let index = 0; index < vector.length; index++) {
+    const value = vector[index] ?? Number.NaN;
+    if (!Number.isFinite(value)) throw semanticSearchUnavailable();
+    squared += value * value;
+  }
+  const norm = Math.sqrt(squared);
+  if (!Number.isFinite(norm) || norm <= MIN_VECTOR_NORM) throw semanticSearchUnavailable();
+  return norm;
+}
+
+export function normalizeQuery(vector: Float32Array, dimensions: number): Float32Array {
+  if (vector.length !== dimensions) throw semanticSearchUnavailable();
+  const norm = vectorNorm(vector);
+  const result = new Float32Array(dimensions);
+  for (let index = 0; index < dimensions; index++) result[index] = (vector[index] ?? 0) / norm;
+  return result;
+}
+
+export function scoreVector(stored: Float32Array, query: Float32Array): number {
+  if (stored.length !== query.length) throw semanticSearchUnavailable();
+  const norm = vectorNorm(stored);
+  if (Math.abs(norm - 1) > STORED_UNIT_NORM_TOLERANCE) throw semanticSearchUnavailable();
+  let score = 0;
+  for (let index = 0; index < stored.length; index++) score += (stored[index] ?? 0) * (query[index] ?? 0);
+  if (!Number.isFinite(score)) throw semanticSearchUnavailable();
+  return Math.max(-1, Math.min(1, score));
+}
+

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -3,7 +3,7 @@ import type { IncomingMessage, Server, ServerResponse } from "node:http";
 import { pathToFileURL } from "node:url";
 import { hostHeaderValidation, originValidation, toNodeHandler } from "@modelcontextprotocol/node";
 import { isAuthorized } from "./auth.js";
-import { loadConfig } from "./config.js";
+import { loadConfig, loadQdrantConfig } from "./config.js";
 import type { CompanionConfig } from "./config.js";
 import { createLogger } from "./logging/logger.js";
 import type { Logger } from "./logging/logger.js";
@@ -25,6 +25,10 @@ import type { McpReadStorage } from "./storage/mcpReadStorage.js";
 import { createMcpReadView } from "./storage/mcpReadStorage.js";
 import { SqliteCompanionStorage } from "./storage/sqliteCompanionStorage.js";
 import { ReconciliationService } from "./sync/reconciliation.js";
+
+import { QdrantVectorBackend } from "./search/qdrantBackend.js";
+import { QdrantClientIndex } from "./search/qdrantIndex.js";
+import type { QdrantVectorIndex } from "./search/qdrantIndex.js";
 
 function sendJson(response: ServerResponse, status: number, value: unknown): void {
   const body = JSON.stringify(value);
@@ -95,6 +99,7 @@ async function routeRequest(
   config: CompanionConfig,
   storage: CompanionStorage,
   reconciliation: ReconciliationService,
+  qdrant: QdrantVectorBackend | undefined,
   handleMcp: (request: IncomingMessage, response: ServerResponse) => Promise<void>,
 ): Promise<void> {
   const url = new URL(request.url ?? "/", "http://companion.invalid");
@@ -122,7 +127,8 @@ async function routeRequest(
   if (url.pathname === "/v1/status") {
     if (request.method !== "GET") methodNotAllowed();
     const status = await storage.getServerStatus();
-    sendJson(response, 200, { status: "ok", protocolVersion: PROTOCOL_VERSION, vaultCount: status.vaultCount });
+    sendJson(response, 200, { status: "ok", protocolVersion: PROTOCOL_VERSION, vaultCount: status.vaultCount,
+      qdrant: qdrant ? await qdrant.status() : { enabled: false, state: "DISABLED" } });
     return;
   }
 
@@ -151,11 +157,17 @@ export function createCompanionServer(
     config.token,
     config.mcp.token,
     config.mcp.embeddingApiKey,
+    config.qdrant?.apiKey ?? "",
   ]),
   queryEmbeddingProvider?: QueryEmbeddingProvider,
+  qdrantIndex?: QdrantVectorIndex,
 ): Server {
+  const qdrantConfig = config.qdrant ?? loadQdrantConfig({});
+  const qdrant = qdrantConfig.enabled ? new QdrantVectorBackend(storage, config.mcp.vaultId,
+    qdrantConfig, qdrantIndex ?? new QdrantClientIndex(qdrantConfig)) : undefined;
+  const unsubscribe = qdrant ? storage.subscribeCommits((notice) => qdrant.onCommit(notice)) : undefined;
   const reconciliation = new ReconciliationService(storage);
-  const mcpHandler = createVaultMcpHandler(createMcpReadView(storage), config.mcp, logger, queryEmbeddingProvider);
+  const mcpHandler = createVaultMcpHandler(createMcpReadView(storage), config.mcp, logger, queryEmbeddingProvider, qdrant);
   const allowedHosts = config.mcp.allowedHosts ?? ["localhost", "127.0.0.1", "[::1]"];
   const checkMcpHost = hostHeaderValidation(allowedHosts);
   const checkMcpOrigin = originValidation(allowedHosts);
@@ -198,12 +210,13 @@ export function createCompanionServer(
     await nodeMcpHandler(limitedRequest, response);
   };
   const server = createServer((request, response) => {
-    void routeRequest(request, response, config, storage, reconciliation, handleMcp).catch((error: unknown) => {
+    void routeRequest(request, response, config, storage, reconciliation, qdrant, handleMcp).catch((error: unknown) => {
       if (!response.headersSent) sendError(response, error, logger);
       else response.destroy();
     });
   });
-  server.once("close", () => void mcpHandler.close());
+  server.once("listening", () => qdrant?.start());
+  server.once("close", () => { unsubscribe?.(); qdrant?.close(); void mcpHandler.close(); });
   return server;
 }
 
@@ -213,6 +226,7 @@ export async function startCompanion(
     config.token,
     config.mcp.token,
     config.mcp.embeddingApiKey,
+    config.qdrant?.apiKey ?? "",
   ]),
 ): Promise<{ server: Server; storage: CompanionStorage }> {
   const storage = new SqliteCompanionStorage(config.dataDir);

--- a/companion/src/storage/companionStorage.ts
+++ b/companion/src/storage/companionStorage.ts
@@ -15,7 +15,17 @@ export interface StoredVaultSnapshot {
   notes: MirroredNote[];
 }
 
+export interface CommitNotice {
+  vaultId: string;
+  generation: number;
+  previousRevision: number;
+  revision: number;
+  replaceVault: boolean;
+  paths: readonly string[];
+}
+
 export interface CompanionStorage {
+  subscribeCommits(listener: (notice: CommitNotice) => void): () => void;
   initialize(): Promise<void>;
   close(): Promise<void>;
   getServerStatus(): Promise<{ vaultCount: number }>;

--- a/companion/src/storage/mcpReadStorage.ts
+++ b/companion/src/storage/mcpReadStorage.ts
@@ -30,9 +30,17 @@ export interface McpStoredVector {
   vector: Float32Array;
 }
 
+export interface SearchSnapshot extends VaultStatus {
+  /** Advances on every commit, including multiple batches of the same generation. */
+  revision: number;
+}
+
 /** Narrow, query-only view used by MCP. It deliberately exposes no mutation method. */
 export interface McpReadStorage {
   getMcpVaultStatus(vaultId: string): Promise<VaultStatus>;
+  getSearchSnapshot(vaultId: string): Promise<SearchSnapshot>;
+  getSearchChunks(vaultId: string, chunkIds: readonly string[]): Promise<Map<string, McpStoredChunk>>;
+  listVectorPage(vaultId: string, dimensions: number, after: string, limit: number, paths?: readonly string[]): McpStoredVector[];
   listMcpNotes(vaultId: string, prefix: string, afterPath: string, limit: number): Promise<McpNoteSummary[]>;
   getMcpNote(vaultId: string, path: string): Promise<McpStoredNote | null>;
   hasMcpNote(vaultId: string, path: string): Promise<boolean>;
@@ -49,6 +57,9 @@ export interface McpReadStorage {
 /** Runtime capability boundary as well as a TypeScript boundary. */
 export function createMcpReadView(storage: McpReadStorage): McpReadStorage {
   return Object.freeze({
+    getSearchSnapshot: storage.getSearchSnapshot.bind(storage),
+    getSearchChunks: storage.getSearchChunks.bind(storage),
+    listVectorPage: storage.listVectorPage.bind(storage),
     getMcpVaultStatus: storage.getMcpVaultStatus.bind(storage),
     listMcpNotes: storage.listMcpNotes.bind(storage),
     getMcpNote: storage.getMcpNote.bind(storage),

--- a/companion/src/storage/migrations.ts
+++ b/companion/src/storage/migrations.ts
@@ -53,6 +53,7 @@ export const MIGRATIONS: readonly Migration[] = [
         ON chunks(vault_id, note_path, ordinal, chunk_id);
     `,
   },
+  { version: 2, sql: "ALTER TABLE vaults ADD COLUMN revision INTEGER NOT NULL DEFAULT 0;" },
 ];
 
 export function runMigrations(database: DatabaseSync): void {

--- a/companion/src/storage/sqliteCompanionStorage.ts
+++ b/companion/src/storage/sqliteCompanionStorage.ts
@@ -15,8 +15,9 @@ import type {
   SyncOperation,
   VaultStatus,
 } from "../protocol/types.js";
-import type { CompanionStorage, StoredVaultSnapshot } from "./companionStorage.js";
+import type { CommitNotice, CompanionStorage, StoredVaultSnapshot } from "./companionStorage.js";
 import type {
+  SearchSnapshot,
   McpNoteSummary,
   McpReadStorage,
   McpStoredChunk,
@@ -26,6 +27,7 @@ import type {
 import { runMigrations } from "./migrations.js";
 
 interface VaultRow {
+  revision: number;
   vault_id: string;
   generation: number;
   descriptor_json: string;
@@ -154,6 +156,19 @@ function mcpChunk(row: McpChunkRow): McpStoredChunk {
 
 export class SqliteCompanionStorage implements CompanionStorage, McpReadStorage {
   private database: DatabaseSync | null = null;
+  private readonly commitListeners = new Set<(notice: CommitNotice) => void>();
+
+  subscribeCommits(listener: (notice: CommitNotice) => void): () => void {
+    this.commitListeners.add(listener);
+    return () => { this.commitListeners.delete(listener); };
+  }
+
+  private publishCommit(notice: CommitNotice): void {
+    for (const listener of this.commitListeners) {
+      // Derived observers can never make an authoritative commit fail.
+      try { listener(notice); } catch { /* Secondary work is isolated. */ }
+    }
+  }
 
   constructor(private readonly dataDir: string, private readonly filename = "companion.sqlite") {}
 
@@ -209,6 +224,34 @@ export class SqliteCompanionStorage implements CompanionStorage, McpReadStorage 
       chunkCount: counts.chunk_count,
       descriptor: parseDescriptor(row),
     };
+  }
+
+  async getSearchSnapshot(vaultId: string): Promise<SearchSnapshot> {
+    const revision = this.vaultRow(vaultId)?.revision ?? 0;
+    return { ...await this.getVaultStatus(vaultId), revision };
+  }
+
+  async getSearchChunks(vaultId: string, chunkIds: readonly string[]): Promise<Map<string, McpStoredChunk>> {
+    if (chunkIds.length === 0) return new Map();
+    const rows = this.db().prepare(`
+      SELECT chunk_id, note_path, ordinal, heading_path_json, text,
+             source_start_offset, source_end_offset, source_start_line, source_end_line
+      FROM chunks WHERE vault_id = ? AND chunk_id IN (${chunkIds.map(() => "?").join(",")})
+    `).all(vaultId, ...chunkIds) as unknown as McpChunkRow[];
+    return new Map(rows.map((row) => [row.chunk_id, mcpChunk(row)]));
+  }
+
+  listVectorPage(vaultId: string, dimensions: number, after: string, limit: number, paths?: readonly string[]): McpStoredVector[] {
+    const pathClause = paths ? ` AND note_path IN (${paths.map(() => "?").join(",")})` : "";
+    const rows = this.db().prepare(`
+      SELECT chunk_id, note_path, ordinal, heading_path_json,
+             source_start_offset, source_end_offset, source_start_line, source_end_line, embedding
+      FROM chunks WHERE vault_id = ? AND chunk_id > ? ${pathClause} ORDER BY chunk_id LIMIT ?
+    `).all(vaultId, after, ...(paths ?? []), limit) as unknown as McpVectorRow[];
+    return rows.map((row) => ({
+      ...mcpChunk({ ...row, text: "" }),
+      vector: decodeFloatVector(row.embedding, dimensions),
+    }));
   }
 
   async getMcpVaultStatus(vaultId: string): Promise<VaultStatus> {
@@ -357,17 +400,23 @@ export class SqliteCompanionStorage implements CompanionStorage, McpReadStorage 
     if (current && !batch.replaceVault && !descriptorEqual(parseDescriptor(current), batch.descriptor)) {
       throw new ProtocolError(409, "DESCRIPTOR_MISMATCH", "Incoming vectors use a different semantic descriptor.");
     }
+    const revision = (current?.revision ?? 0) + 1;
+    const paths = [...new Set(batch.operations.flatMap((operation) => operation.type === "DELETE"
+      ? [operation.path] : operation.type === "RENAME" ? [operation.oldPath, operation.note.path] : [operation.note.path]))];
     database.exec("BEGIN IMMEDIATE");
     try {
       if (batch.replaceVault) database.prepare("DELETE FROM vaults WHERE vault_id = ?").run(vaultId);
       this.upsertVault(vaultId, batch);
       for (const operation of batch.operations) this.applyOperation(vaultId, operation);
+      database.prepare("UPDATE vaults SET revision = ? WHERE vault_id = ?").run(revision, vaultId);
       database.exec("COMMIT");
     } catch (error) {
       database.exec("ROLLBACK");
       if (error instanceof ProtocolError) throw error;
       throw new ProtocolError(500, "STORAGE_ERROR", "The synchronization batch could not be committed.");
     }
+    this.publishCommit({ vaultId, generation: batch.generation, previousRevision: current?.revision ?? 0,
+      revision, replaceVault: batch.replaceVault ?? false, paths });
     return {
       protocolVersion: PROTOCOL_VERSION,
       generation: batch.generation,
@@ -431,7 +480,7 @@ export class SqliteCompanionStorage implements CompanionStorage, McpReadStorage 
 
   private vaultRow(vaultId: string): VaultRow | null {
     return (this.db().prepare(`
-      SELECT vault_id, generation, descriptor_json, embedding_space_id, dimensions
+      SELECT vault_id, generation, descriptor_json, embedding_space_id, dimensions, revision
       FROM vaults WHERE vault_id = ?
     `).get(vaultId) as VaultRow | undefined) ?? null;
   }

--- a/companion/tests/mcpSemanticSearch.test.ts
+++ b/companion/tests/mcpSemanticSearch.test.ts
@@ -67,8 +67,10 @@ describe("SQLite MCP semantic retrieval", () => {
       return value;
     });
     await storage.applyBatch(VAULT_A, upsertBatch(1, notes));
-    const results = await new SqliteSemanticSearch(storage, provider(new Float32Array([1, 0, 0])))
+    const pending = new SqliteSemanticSearch(storage, provider(new Float32Array([1, 0, 0])))
       .search(VAULT_A, "bounded", 5);
+    await expect(pending).resolves.toHaveLength(5);
+    const results = await pending;
     expect(results).toHaveLength(5);
     expect(results.map((item) => item.chunkId)).toEqual(["chunk-00", "chunk-01", "chunk-02", "chunk-03", "chunk-04"]);
     expect(JSON.stringify(results)).not.toMatch(/embedding|vector/iu);

--- a/companion/tests/qdrantBackend.test.ts
+++ b/companion/tests/qdrantBackend.test.ts
@@ -1,0 +1,303 @@
+import { DatabaseSync } from "node:sqlite";
+import type { MirroredNote, SemanticDescriptor } from "../src/protocol/types.js";
+import type { McpSearchResult } from "../src/mcp/semanticSearch.js";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { loadQdrantConfig } from "../src/config.js";
+import { buildDescriptorEmbeddingSpaceId } from "../src/mcp/descriptor.js";
+import { SemanticSearchService, SqliteSemanticSearch } from "../src/mcp/semanticSearch.js";
+import { QdrantVectorBackend } from "../src/search/qdrantBackend.js";
+import { collectionName, pointId } from "../src/search/qdrantIndex.js";
+import { SqliteCompanionStorage } from "../src/storage/sqliteCompanionStorage.js";
+import { descriptor, note, upsertBatch, VAULT_A, VAULT_B } from "./fixtures.js";
+import { FakeQdrantIndex } from "./qdrantFixture.js";
+
+const config = loadQdrantConfig({ QDRANT_ENABLED: "true", QDRANT_API_KEY: "super-secret-qdrant" });
+function canonical(model: string, dimensions = 3): SemanticDescriptor {
+  const value = descriptor({ model, dimensions });
+  value.embeddingSpaceId = buildDescriptorEmbeddingSpaceId(value);
+  return value;
+}
+function gate(): { promise: Promise<void>; release: () => void } {
+  let release!: () => void;
+  const promise = new Promise<void>((resolve) => { release = resolve; });
+  return { promise, release };
+}
+
+describe("Qdrant derived search lifecycle", () => {
+  let directory: string;
+  let storage: SqliteCompanionStorage;
+  let index: FakeQdrantIndex;
+  let backend: QdrantVectorBackend;
+  const provider = { embedQuery: vi.fn(async () => new Float32Array([1, 0, 0])) };
+  let service: SemanticSearchService;
+  let unsubscribe: () => void;
+  beforeEach(async () => {
+    directory = await mkdtemp(join(tmpdir(), "qdrant-lifecycle-"));
+    storage = new SqliteCompanionStorage(directory);
+    await storage.initialize();
+    index = new FakeQdrantIndex();
+    backend = new QdrantVectorBackend(storage, VAULT_A, config, index);
+    unsubscribe = storage.subscribeCommits((notice) => backend.onCommit(notice));
+    provider.embedQuery.mockClear();
+    service = new SemanticSearchService(storage, provider, backend);
+  });
+  afterEach(async () => { unsubscribe(); backend.close(); await storage.close(); await rm(directory, { recursive: true, force: true }); });
+  async function seed(count = 3): Promise<MirroredNote[]> {
+    const notes = Array.from({ length: count }, (_, i) => {
+      const value = note(`${i}.md`, `stored content ${i}`, i === 2 ? [0, 1, 0] : [1, 0, 0]);
+      value.chunks[0]!.chunkId = `id-${String(i).padStart(4, "0")}`;
+      return value;
+    });
+    await storage.applyBatch(VAULT_A, upsertBatch(1, notes));
+    return notes;
+  }
+  async function search(): Promise<McpSearchResult[]> { return service.search(VAULT_A, "query only", 2); }
+  async function expectSqlite(): Promise<void> {
+    const calls = index.calls.filter((call) => call.method === "search").length;
+    expect(await search()).toHaveLength(2);
+    expect(index.calls.filter((call) => call.method === "search")).toHaveLength(calls);
+    expect((await backend.status()).lastSearchBackend).toBe("sqlite");
+  }
+  it("disabled uses SQLite and never contacts Qdrant", async () => {
+    backend.close(); unsubscribe();
+    backend = new QdrantVectorBackend(storage, VAULT_A, { ...config, enabled: false }, index);
+    service = new SemanticSearchService(storage, provider, backend);
+    await seed(); await backend.reconcile(); await expectSqlite();
+    expect((await backend.status()).state).toBe("DISABLED"); expect(index.calls).toEqual([]);
+  });
+  it("unavailable and ERROR fall back with one embedding, later recovery needs no resync", async () => {
+    await seed(); index.fail = "all";
+    await backend.reconcile(); expect((await backend.status()).state).toBe("ERROR");
+    await expectSqlite(); expect(provider.embedQuery).toHaveBeenCalledExactlyOnceWith(descriptor(), "query only");
+    index.fail = null; await backend.reconcile(); expect((await backend.status()).state).toBe("READY");
+  });
+  it("BUILDING never publishes a partial index and falls back", async () => {
+    await seed(); const blocked = gate(); const entered = gate();
+    index.before = async (method): Promise<void> => { if (method === "upsert") { entered.release(); await blocked.promise; } };
+    const build = backend.reconcile(); await entered.promise;
+    expect((await backend.status()).state).toBe("BUILDING"); await expectSqlite();
+    blocked.release(); await build; expect((await backend.status()).state).toBe("READY");
+  });
+  it("STALE falls back before initial reconciliation", async () => { await seed(); await expectSqlite(); });
+  it("READY exact state uses Qdrant with one query embedding and authoritative parity", async () => {
+    await seed(); const before = await storage.readVault(VAULT_A);
+    await backend.reconcile(); expect(provider.embedQuery).not.toHaveBeenCalled();
+    const actual = await search();
+    expect(index.calls.some((call) => call.method === "search")).toBe(true);
+    expect((await backend.status()).lastSearchBackend).toBe("qdrant");
+    expect(provider.embedQuery).toHaveBeenCalledExactlyOnceWith(descriptor(), "query only");
+    const expected = await new SqliteSemanticSearch(storage, provider).search(VAULT_A, "query only", 2);
+    expect(actual).toEqual(expected); expect(await storage.readVault(VAULT_A)).toEqual(before);
+    expect(actual[0]?.text).toBe("0\n\nstored content 0");
+  });
+  it("Qdrant search failure falls back using exactly one query embedding", async () => {
+    await seed(); await backend.reconcile(); index.fail = "search";
+    await expect(search()).resolves.toHaveLength(2);
+    expect(provider.embedQuery).toHaveBeenCalledExactlyOnceWith(descriptor(), "query only");
+    expect((await backend.status()).lastSearchBackend).toBe("sqlite");
+  });
+  it("requires exact generation, revision, vault and semantic space for readiness", async () => {
+    await seed(); await backend.reconcile(); const snapshot = await storage.getSearchSnapshot(VAULT_A);
+    expect(backend.available(snapshot)).toBe(true);
+    expect(backend.available({ ...snapshot, generation: 2 })).toBe(false);
+    expect(backend.available({ ...snapshot, revision: 2 })).toBe(false);
+    expect(backend.available({ ...snapshot, vaultId: VAULT_B })).toBe(false);
+    expect(backend.available({ ...snapshot, descriptor: canonical("other") })).toBe(false);
+    expect(backend.available({ ...snapshot, descriptor: { ...descriptor(), model: "tampered" } })).toBe(false);
+  });
+  it("same-generation same-count edits invalidate readiness and increment persisted revision", async () => {
+    const notes = await seed(); await backend.reconcile(); const before = await storage.getSearchSnapshot(VAULT_A);
+    notes[0]!.content = "changed"; notes[0]!.chunks[0]!.text = "changed";
+    await storage.applyBatch(VAULT_A, upsertBatch(1, notes));
+    expect((await backend.status()).state).toBe("STALE");
+    expect((await storage.getSearchSnapshot(VAULT_A)).revision).toBe(before.revision + 1);
+    await expectSqlite(); await backend.reconcile();
+    expect((await search())[0]?.text).toBe("changed");
+  });
+  it("initial rebuild is bounded, deterministic, from stored SQLite vectors with zero embeddings", async () => {
+    await seed(260); await backend.reconcile();
+    const name = collectionName(config.collectionPrefix, VAULT_A, descriptor().embeddingSpaceId);
+    const points = structuredClone(index.collections.get(name)!.points);
+    expect(index.calls.filter((call) => call.method === "upsert").map((call) => call.size)).toEqual([128, 128, 4]);
+    backend.invalidate(); await backend.reconcile();
+    expect([...index.collections.get(name)!.points.keys()]).toEqual([...points.keys()]);
+    expect(index.collections.get(name)!.points.get(pointId(VAULT_A, "id-0000"))?.vector).toEqual([1, 0, 0]);
+    expect(provider.embedQuery).not.toHaveBeenCalled();
+  });
+  it("empty existing vault builds READY and absent vault stays SQLite", async () => {
+    await backend.reconcile(); expect((await backend.status()).state).toBe("STALE");
+    await storage.applyBatch(VAULT_A, upsertBatch(1, [])); await backend.reconcile();
+    expect((await backend.status()).state).toBe("READY"); expect(await search()).toEqual([]);
+    expect(provider.embedQuery).not.toHaveBeenCalled();
+  });
+  it("partial build failure never READY and later rebuild recovers", async () => {
+    await seed(130); let uploads = 0;
+    index.before = async (method): Promise<void> => { if (method === "upsert" && ++uploads === 2) throw new Error("failure"); };
+    await backend.reconcile(); expect((await backend.status()).state).toBe("ERROR");
+    await expectSqlite(); index.before = async (): Promise<void> => {}; await backend.reconcile();
+    expect((await backend.status()).state).toBe("READY");
+  });
+  it("generation changes during a build prevent READY publication", async () => {
+    await seed(); let changed = false;
+    index.before = async (method): Promise<void> => {
+      if (method === "upsert" && !changed) { changed = true; await storage.applyBatch(VAULT_A, upsertBatch(2, [note("new.md", "new", [1, 0, 0])])); }
+    };
+    await backend.reconcile(); expect((await backend.status()).state).toBe("STALE");
+    expect(backend.available(await storage.getSearchSnapshot(VAULT_A))).toBe(false);
+    await backend.reconcile(); expect((await backend.status()).indexedGeneration).toBe(2);
+  });
+  it("descriptor replacement never queries old space, builds new vectors and leaves old collection alone", async () => {
+    await seed(); await backend.reconcile(); const old = (await backend.status()).collection;
+    const next = canonical("replacement");
+    await storage.applyBatch(VAULT_A, upsertBatch(2, [note("new.md", "new", [0, 0, 1])], { replaceVault: true, descriptor: next }));
+    expect(await search()).toHaveLength(1);
+    expect(index.calls.filter((call) => call.method === "search")).toEqual([]);
+    await backend.reconcile(); await search();
+    const current = (await backend.status()).collection;
+    expect(current).not.toBe(old); expect(index.collections.has(old!)).toBe(true);
+    expect(index.calls.filter((call) => call.method === "search").map((call) => call.collection)).toEqual([current]);
+    expect([...index.collections.get(current!)!.points.values()][0]?.vector).toEqual([0, 0, 1]);
+    expect([...index.collections.get(current!)!.points.values()][0]?.payload.embeddingSpaceId).toBe(next.embeddingSpaceId);
+  });
+  it("dimension replacement builds a different collection without converting SQLite vectors", async () => {
+    await seed(); await backend.reconcile();
+    await storage.applyBatch(VAULT_A, upsertBatch(2, [note("new.md", "new", [1, 0])], { replaceVault: true, descriptor: canonical("two", 2) }));
+    await backend.reconcile(); const status = await backend.status();
+    expect(status.state).toBe("READY"); expect(index.collections.get(status.collection!)?.dimensions).toBe(2);
+    expect(provider.embedQuery).not.toHaveBeenCalled();
+  });
+  it("incremental UPSERT replaces vectors and adds chunks without a full rebuild", async () => {
+    const notes = await seed(); await backend.reconcile(); const clears = index.calls.filter((call) => call.method === "clear").length;
+    notes[0]!.chunks[0]!.embedding = [0, 0, 1];
+    await storage.applyBatch(VAULT_A, upsertBatch(2, [notes[0]!, note("new.md", "new", [1, 0, 0])]));
+    await backend.reconcile(); expect((await backend.status()).state).toBe("READY");
+    expect(index.calls.filter((call) => call.method === "clear")).toHaveLength(clears);
+    const points = index.collections.get((await backend.status()).collection!)!.points;
+    expect(points.get(pointId(VAULT_A, "id-0000"))?.vector).toEqual([0, 0, 1]); expect(points.size).toBe(4);
+  });
+  it("DELETE and RENAME remove old points before publishing current generation", async () => {
+    await seed(); await backend.reconcile();
+    await storage.applyBatch(VAULT_A, upsertBatch(2, [], { operations: [
+      { type: "DELETE", path: "0.md" }, { type: "RENAME", oldPath: "1.md", note: note("renamed.md", "renamed", [1, 0, 0]) },
+    ] }));
+    expect((await search()).map((r) => r.path)).toEqual(["renamed.md", "2.md"]);
+    expect((await backend.status()).state).toBe("STALE"); await backend.reconcile();
+    const points = index.collections.get((await backend.status()).collection!)!.points;
+    expect(points.has(pointId(VAULT_A, "id-0000"))).toBe(false); expect(points.has(pointId(VAULT_A, "id-0001"))).toBe(false);
+    expect((await search()).map((r) => r.path)).toEqual(["renamed.md", "2.md"]);
+  });
+  it.each(["delete", "upsert", "stamp"])("incremental %s failure preserves committed SQLite sync and recovers", async (failure) => {
+    await seed(); await backend.reconcile(); index.fail = failure;
+    const result = await storage.applyBatch(VAULT_A, upsertBatch(2, [note("new.md", "new", [1, 0, 0])]));
+    expect(result.applied).toBe(true); await backend.reconcile(); expect((await backend.status()).state).toBe("ERROR");
+    expect((await storage.getVaultStatus(VAULT_A)).generation).toBe(2); await expectSqlite();
+    index.fail = null; await backend.reconcile(); expect((await backend.status()).state).toBe("READY");
+  });
+  it("SQLite COMMIT precedes every Qdrant mutation and failed transaction never advances Qdrant", async () => {
+    const events: number[] = [];
+    storage.subscribeCommits(() => { events.push(storage.listVectorPage(VAULT_A, 3, "", 10).length); });
+    await seed(); await backend.reconcile(); expect(events).toEqual([3]);
+    index.before = async (): Promise<void> => { expect((await storage.getVaultStatus(VAULT_A)).generation).toBe(2); };
+    await storage.applyBatch(VAULT_A, upsertBatch(2, [note("new.md", "new", [1, 0, 0])])); await backend.reconcile();
+    const snapshot = await storage.readVault(VAULT_A); const calls = index.calls.length; const notifications = events.length;
+    const invalid = note("bad.md", "bad", [1, 0, 0]); invalid.chunks[0]!.chunkId = "id-0000";
+    await expect(storage.applyBatch(VAULT_A, upsertBatch(3, [invalid]))).rejects.toMatchObject({ code: "STORAGE_ERROR" });
+    expect(index.calls).toHaveLength(calls); expect(events).toHaveLength(notifications); expect(await storage.readVault(VAULT_A)).toEqual(snapshot);
+  });
+  it("independent SQLite reader sees COMMIT before observers are notified", async () => {
+    const reader = new DatabaseSync(join(directory, "companion.sqlite"), { readOnly: true });
+    const observed: unknown[] = [];
+    const stop = storage.subscribeCommits(() => {
+      observed.push(reader.prepare("SELECT generation, revision FROM vaults WHERE vault_id = ?").get(VAULT_A));
+    });
+    try {
+      await seed();
+      expect(observed).toEqual([{ generation: 1, revision: 1 }]);
+    } finally { stop(); reader.close(); }
+  });
+  it("a SQLite COMMIT failure rolls back and never notifies the derived index", async () => {
+    await seed(); await backend.reconcile();
+    const before = await storage.getSearchSnapshot(VAULT_A);
+    const snapshot = await storage.readVault(VAULT_A);
+    const notices = vi.fn(); storage.subscribeCommits(notices);
+    const execute = DatabaseSync.prototype.exec;
+    const commit = vi.spyOn(DatabaseSync.prototype, "exec").mockImplementation(function (this: DatabaseSync, sql: string): void {
+      if (sql === "COMMIT") throw new Error("simulated commit failure");
+      execute.call(this, sql);
+    });
+    try {
+      await expect(storage.applyBatch(VAULT_A, upsertBatch(2, [note("new.md", "new", [1, 0, 0])])))
+        .rejects.toMatchObject({ code: "STORAGE_ERROR" });
+    } finally { commit.mockRestore(); }
+    expect(notices).not.toHaveBeenCalled(); expect(await storage.readVault(VAULT_A)).toEqual(snapshot);
+    expect(await storage.getSearchSnapshot(VAULT_A)).toEqual(before); expect(backend.available(before)).toBe(true);
+  });
+  it("upgrades an existing Stage 9 mirror without changing notes or vectors", async () => {
+    await seed(); const before = await storage.readVault(VAULT_A);
+    backend.close(); unsubscribe(); await storage.close();
+    const old = new DatabaseSync(join(directory, "companion.sqlite"));
+    old.exec("ALTER TABLE vaults DROP COLUMN revision; PRAGMA user_version = 1"); old.close();
+    storage = new SqliteCompanionStorage(directory); await storage.initialize();
+    expect(await storage.readVault(VAULT_A)).toEqual(before);
+    expect((await storage.getSearchSnapshot(VAULT_A)).revision).toBe(0);
+    backend = new QdrantVectorBackend(storage, VAULT_A, config, index); await backend.reconcile();
+    expect((await backend.status()).state).toBe("READY"); expect(provider.embedQuery).not.toHaveBeenCalled();
+  });
+  it("non-axis vectors preserve SQLite ranking and cosine scores within Float32 tolerance", async () => {
+    await storage.applyBatch(VAULT_A, upsertBatch(1, [note("A.md", "a", [0.6, 0.8, 0]),
+      note("B.md", "b", [Math.SQRT1_2, Math.SQRT1_2, 0]), note("C.md", "c", [-1, 0, 0])]));
+    await backend.reconcile(); const actual = await search();
+    const expected = await new SqliteSemanticSearch(storage, provider).search(VAULT_A, "query only", 2);
+    expect(actual.map((row) => row.chunkId)).toEqual(expected.map((row) => row.chunkId));
+    actual.forEach((row, i) => expect(Math.abs(row.score - expected[i]!.score)).toBeLessThanOrEqual(1e-6));
+    expect((await backend.status()).lastSearchBackend).toBe("qdrant");
+  });
+  it("observer failure cannot make a successful SQLite sync fail", async () => {
+    storage.subscribeCommits(() => { throw new Error("derived failure"); });
+    await expect(storage.applyBatch(VAULT_A, upsertBatch(1, [note("A.md", "a", [1, 0, 0])]))).resolves.toMatchObject({ applied: true });
+    expect((await storage.getVaultStatus(VAULT_A)).chunkCount).toBe(1);
+  });
+  it("missing SQLite hydration discards all Qdrant candidates and falls back with one embedding", async () => {
+    await seed(); await backend.reconcile(); index.searchResult = [{ chunkId: "id-0000", score: 1 }, { chunkId: "missing", score: 1 }];
+    const result = await search(); expect(result.map((r) => r.chunkId)).toEqual(["id-0000", "id-0001"]);
+    expect(provider.embedQuery).toHaveBeenCalledTimes(1); expect((await backend.status()).lastSearchBackend).toBe("sqlite");
+  });
+  it.each([Number.NaN, 2, -2])("malformed derived score %s falls back", async (score) => {
+    await seed(); await backend.reconcile(); index.searchResult = [{ chunkId: "id-0000", score }];
+    expect(await search()).toHaveLength(2); expect((await backend.status()).lastSearchBackend).toBe("sqlite");
+  });
+  it("same-space commit during Qdrant search falls back to current SQLite with the same vector", async () => {
+    await seed(); await backend.reconcile(); index.before = async (method): Promise<void> => {
+      if (method === "search") await storage.applyBatch(VAULT_A, upsertBatch(2, [], { operations: [{ type: "DELETE", path: "0.md" }] }));
+    };
+    expect((await search()).map((r) => r.path)).toEqual(["1.md", "2.md"]); expect(provider.embedQuery).toHaveBeenCalledTimes(1);
+  });
+  it("different-space commit during Qdrant search rejects the old query vector", async () => {
+    await seed(); await backend.reconcile(); index.before = async (method): Promise<void> => {
+      if (method === "search") await storage.applyBatch(VAULT_A, upsertBatch(2, [], { replaceVault: true, descriptor: canonical("new") }));
+    };
+    await expect(search()).rejects.toMatchObject({ code: "SEMANTIC_SEARCH_UNAVAILABLE" }); expect(provider.embedQuery).toHaveBeenCalledTimes(1);
+  });
+  it("restart distrusts existing Qdrant state and rebuilds using persistent SQLite revision", async () => {
+    await seed(); await backend.reconcile(); const before = await storage.getSearchSnapshot(VAULT_A);
+    unsubscribe(); backend.close(); await storage.close(); storage = new SqliteCompanionStorage(directory); await storage.initialize();
+    backend = new QdrantVectorBackend(storage, VAULT_A, config, index); service = new SemanticSearchService(storage, provider, backend);
+    expect(await storage.getSearchSnapshot(VAULT_A)).toEqual(before); await expectSqlite(); await backend.reconcile();
+    expect((await backend.status()).state).toBe("READY");
+  });
+  it("safe diagnostic status never includes Qdrant key or upstream error text", async () => {
+    await seed(); index.fail = "all"; await backend.reconcile();
+    const output = JSON.stringify(await backend.status());
+    expect(output).not.toContain(config.apiKey); expect(output).not.toContain("upstream"); expect(output).not.toContain("stored content");
+    expect((await backend.status()).lastErrorCode).toBe("QDRANT_INVALID_INDEX");
+  });
+  it("coalesces pending commits into one full rebuild", async () => {
+    await seed(); await backend.reconcile(); const clears = index.calls.filter((call) => call.method === "clear").length;
+    for (let i = 2; i < 10; i++) await storage.applyBatch(VAULT_A, upsertBatch(i, [note("x.md", String(i), [1, 0, 0])]));
+    await backend.reconcile(); expect(index.calls.filter((call) => call.method === "clear")).toHaveLength(clears + 1);
+    expect((await backend.status()).indexedGeneration).toBe(9);
+  });
+});

--- a/companion/tests/qdrantFixture.ts
+++ b/companion/tests/qdrantFixture.ts
@@ -1,0 +1,58 @@
+import type { IndexPoint, IndexSpec, QdrantVectorIndex } from "../src/search/qdrantIndex.js";
+import { identityHash, QdrantIndexError } from "../src/search/qdrantIndex.js";
+import { compareCandidates } from "../src/search/vectorBackend.js";
+import type { VectorCandidate } from "../src/search/vectorBackend.js";
+
+export class FakeQdrantIndex implements QdrantVectorIndex {
+  readonly collections = new Map<string, { owner: string; dimensions: number; points: Map<string, IndexPoint> }>();
+  readonly calls: Array<{ method: string; collection: string; size?: number }> = [];
+  before: (method: string, spec: IndexSpec) => Promise<void> = () => Promise.resolve();
+  fail: string | null = null;
+  searchResult: VectorCandidate[] | null = null;
+  private async operation(method: string, spec: IndexSpec, size?: number): Promise<void> {
+    this.calls.push({ method, collection: spec.collection, ...(size === undefined ? {} : { size }) });
+    await this.before(method, spec);
+    if (this.fail === method || this.fail === "all") throw new Error("upstream api-key=super-secret-qdrant");
+  }
+  async ensureCollection(spec: IndexSpec): Promise<void> {
+    await this.operation("ensure", spec);
+    if (!this.collections.has(spec.collection)) this.collections.set(spec.collection, { owner: spec.owner, dimensions: spec.dimensions, points: new Map() });
+    const collection = this.collections.get(spec.collection)!;
+    if (collection.owner !== spec.owner || collection.dimensions !== spec.dimensions) throw new QdrantIndexError();
+  }
+  async clear(spec: IndexSpec): Promise<void> { await this.operation("clear", spec); this.collections.get(spec.collection)!.points.clear(); }
+  async upsert(spec: IndexSpec, points: IndexPoint[]): Promise<void> {
+    await this.operation("upsert", spec, points.length);
+    for (const point of points) this.collections.get(spec.collection)!.points.set(point.id, structuredClone(point));
+  }
+  async deleteNotes(spec: IndexSpec, paths: readonly string[]): Promise<void> {
+    await this.operation("delete", spec, paths.length);
+    const hashes = paths.map(identityHash);
+    for (const [id, point] of this.collections.get(spec.collection)!.points) {
+      if (hashes.includes(point.payload.noteKey)) this.collections.get(spec.collection)!.points.delete(id);
+    }
+  }
+  async stamp(spec: IndexSpec): Promise<void> {
+    await this.operation("stamp", spec);
+    for (const point of this.collections.get(spec.collection)!.points.values()) {
+      Object.assign(point.payload, { generation: spec.generation, revision: spec.revision, buildId: spec.buildId });
+    }
+  }
+  async verify(spec: IndexSpec): Promise<void> {
+    await this.operation("verify", spec);
+    const collection = this.collections.get(spec.collection);
+    if (!collection || collection.owner !== spec.owner || collection.dimensions !== spec.dimensions || collection.points.size !== spec.count ||
+        [...collection.points.values()].some(({ payload: p }) => p.vaultId !== spec.vaultId || p.embeddingSpaceId !== spec.embeddingSpaceId ||
+          p.generation !== spec.generation || p.revision !== spec.revision || p.buildId !== spec.buildId)) throw new QdrantIndexError();
+  }
+  async search(spec: IndexSpec, vector: Float32Array, limit: number): Promise<VectorCandidate[]> {
+    await this.operation("search", spec);
+    if (this.searchResult) return this.searchResult;
+    await this.verify(spec);
+    return [...this.collections.get(spec.collection)!.points.values()].map((point) => ({
+      chunkId: point.payload.chunkId,
+      score: point.vector.reduce((total, value, i) => total + value * vector[i]!, 0),
+    })).sort(compareCandidates).slice(0, limit);
+  }
+  close(): void { /* In-memory fixture owns no handles. */ }
+}

--- a/companion/tests/qdrantIndex.test.ts
+++ b/companion/tests/qdrantIndex.test.ts
@@ -1,0 +1,204 @@
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { loadQdrantConfig } from "../src/config.js";
+import { collectionName, indexPoint, indexSpec, pointId, QdrantClientIndex, QdrantIndexError } from "../src/search/qdrantIndex.js";
+import { descriptor, VAULT_A, VAULT_B } from "./fixtures.js";
+
+const secret = "super-secret-qdrant";
+const config = loadQdrantConfig({ QDRANT_ENABLED: "true", QDRANT_API_KEY: secret });
+const spec = indexSpec(config.collectionPrefix, {
+  vaultId: VAULT_A, protocolVersion: 1, exists: true, generation: 7, revision: 12,
+  descriptor: descriptor(), noteCount: 1, chunkCount: 1,
+}, "test-build");
+const record = { chunkId: "logical-chunk", path: "Private.md", ordinal: 0, headingPath: ["heading"],
+  source: { startOffset: 0, endOffset: 1, startLine: 0, endLine: 1 }, vector: new Float32Array([1, 0, 0]) };
+const point = indexPoint(spec, record);
+function response(result: unknown): Response {
+  return new Response(JSON.stringify({ status: "ok", result }), { headers: { "content-type": "application/json" } });
+}
+function stub(): ReturnType<typeof vi.fn<typeof globalThis.fetch>> {
+  const fetch = vi.fn<typeof globalThis.fetch>(async (input, init) => {
+    const url = new URL(String(input));
+    if (url.pathname.endsWith("/exists")) return response({ exists: true });
+    if (url.pathname.endsWith("/count")) return response({ count: spec.count });
+    if (url.pathname.endsWith("/query")) return response({ points: [{ id: point.id, score: 1, payload: point.payload }] });
+    if (init?.method === "GET") return response({ status: "green", config: {
+      params: { vectors: { size: 3, distance: "Cosine" } }, metadata: { vaultAuditOwner: spec.owner },
+    } });
+    return response({ status: "completed", operation_id: 1 });
+  });
+  vi.stubGlobal("fetch", fetch);
+  return fetch;
+}
+
+afterEach(() => { vi.unstubAllGlobals(); vi.restoreAllMocks(); });
+
+describe("Qdrant configuration and identity", () => {
+  it("is disabled by default with local URL and bounded timeout", () => {
+    expect(loadQdrantConfig({})).toEqual({ enabled: false, url: "http://127.0.0.1:6333", apiKey: "",
+      timeoutMs: 5000, collectionPrefix: "vault_audit", allowInsecureRemoteHttp: false });
+  });
+  it.each(["http://127.0.0.1:6333", "http://localhost:6333", "http://[::1]:6333", "https://q.example", "https://q.example/proxy"])("accepts safe URL %s", (url) => {
+    expect(loadQdrantConfig({ QDRANT_URL: url }).url).toBe(url);
+  });
+  it.each(["junk", "ftp://localhost", `http://user:${secret}@localhost`, `https://q.example/?key=${secret}`, "https://q.example/#fragment"])("rejects unsafe URL without echoing %s", (url) => {
+    expect(() => loadQdrantConfig({ QDRANT_URL: url })).toThrow(/QDRANT_URL/u);
+    try { loadQdrantConfig({ QDRANT_URL: url }); } catch (error) { expect(String(error)).not.toContain(secret); }
+  });
+  it.each(["http://q.example:6333", "http://192.168.0.2:6333", "http://[::ffff:7f00:1]:6333"])("requires explicit remote HTTP override for %s", (url) => {
+    expect(() => loadQdrantConfig({ QDRANT_URL: url })).toThrow(/QDRANT_ALLOW_INSECURE_REMOTE_HTTP/u);
+    expect(loadQdrantConfig({ QDRANT_URL: url, QDRANT_ALLOW_INSECURE_REMOTE_HTTP: "true" }).allowInsecureRemoteHttp).toBe(true);
+  });
+  it.each([{ QDRANT_ENABLED: "yes" }, { QDRANT_TIMEOUT_MS: "0" }, { QDRANT_TIMEOUT_MS: "120001" },
+    { QDRANT_COLLECTION_PREFIX: "../notes" }, { QDRANT_COLLECTION_PREFIX: "x".repeat(33) }])("rejects invalid options %j", (environment) => {
+    expect(() => loadQdrantConfig(environment)).toThrow();
+  });
+  it("hashes collection identities without content or paths and separates spaces and vaults", () => {
+    const name = collectionName("vault_audit", "/absolute/private/vault", "space with content");
+    expect(name).toMatch(/^vault_audit_[a-f0-9]{32}_[a-f0-9]{32}$/u);
+    expect(name).toBe(collectionName("vault_audit", "/absolute/private/vault", "space with content"));
+    expect(name).not.toMatch(/absolute|private|content/u);
+    expect(collectionName("vault_audit", VAULT_A, "space")).not.toBe(collectionName("vault_audit", VAULT_B, "space"));
+    expect(collectionName("vault_audit", VAULT_A, "space")).not.toBe(collectionName("vault_audit", VAULT_A, "other"));
+  });
+  it("uses deterministic collision-resistant UUID point identity", () => {
+    expect(pointId(VAULT_A, "chunk")).toBe(pointId(VAULT_A, "chunk"));
+    expect(pointId(VAULT_A, "chunk")).toMatch(/^[a-f0-9]{8}-[a-f0-9]{4}-8[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$/u);
+    expect(pointId(VAULT_A, "chunk")).not.toBe(pointId(VAULT_B, "chunk"));
+    expect(pointId("ab", "c")).not.toBe(pointId("a", "bc"));
+  });
+  it("point payload has only retrieval identity and never full Markdown or chunk text", () => {
+    const payload = indexPoint(spec, { ...record, text: "# PRIVATE MARKDOWN", content: "full private Markdown" } as typeof record).payload;
+    expect(Object.keys(payload).sort()).toEqual(["buildId", "chunkId", "embeddingSpaceId", "generation", "noteKey", "revision", "vaultId"]);
+    expect(JSON.stringify(payload)).not.toMatch(/PRIVATE|Markdown|Private.md|heading/u);
+    expect(point.vector).toEqual([1, 0, 0]);
+  });
+  it.each([[1, 0], [2, 0, 0], [Number.NaN, 0, 0], [0, 0, 0]].map((vector) => ({ vector })))("rejects invalid stored vector %j without converting it", ({ vector }) => {
+    expect(() => indexPoint(spec, { ...record, vector: new Float32Array(vector) })).toThrow();
+  });
+});
+
+describe("official Qdrant SDK adapter", () => {
+  it("creates a cosine collection of exact dimensions with ownership metadata", async () => {
+    const fetch = stub();
+    fetch.mockResolvedValueOnce(response({ exists: false })).mockResolvedValueOnce(response(true));
+    const index = new QdrantClientIndex(config); await index.ensureCollection(spec);
+    const creation = fetch.mock.calls.find(([, init]) => init?.method === "PUT")!;
+    expect(JSON.parse(creation[1]!.body as string)).toEqual({ vectors: { size: 3, distance: "Cosine" }, metadata: { vaultAuditOwner: spec.owner } });
+  });
+  it.each([{ size: 4, distance: "Cosine" }, { size: 3, distance: "Dot" }])("rejects incompatible collection %j without clearing it", async (vectors) => {
+    const fetch = stub(); fetch.mockResolvedValueOnce(response({ exists: true })).mockResolvedValueOnce(response({ status: "green",
+      config: { params: { vectors }, metadata: { vaultAuditOwner: spec.owner } } }));
+    await expect(new QdrantClientIndex(config).ensureCollection(spec)).rejects.toBeInstanceOf(QdrantIndexError);
+    expect(fetch.mock.calls).toHaveLength(2);
+  });
+  it("never clears an unknown owner's collection", async () => {
+    const fetch = stub(); fetch.mockResolvedValueOnce(response({ status: "green", config: {
+      params: { vectors: { size: 3, distance: "Cosine" } }, metadata: { vaultAuditOwner: "foreign" },
+    } }));
+    await expect(new QdrantClientIndex(config).clear(spec)).rejects.toBeInstanceOf(QdrantIndexError);
+    expect(fetch.mock.calls).toHaveLength(1);
+  });
+  it("upserts bounded points, deletes hashed note identities and waits for mutation completion", async () => {
+    const fetch = stub(); const index = new QdrantClientIndex(config);
+    await index.upsert(spec, [point]); await index.deleteNotes(spec, [record.path]); await index.stamp(spec);
+    expect(fetch.mock.calls.every(([url]) => String(url).includes("wait=true"))).toBe(true);
+    expect(JSON.parse(fetch.mock.calls[0]![1]!.body as string)).toEqual({ points: [point] });
+    expect(JSON.stringify(fetch.mock.calls)).not.toContain(record.path);
+    await expect(index.upsert(spec, Array.from({ length: 129 }, () => point))).rejects.toBeInstanceOf(QdrantIndexError);
+    await expect(index.upsert(spec, [{ ...point, vector: [1, 0] }])).rejects.toBeInstanceOf(QdrantIndexError);
+  });
+  it("requires completed rather than merely acknowledged mutations", async () => {
+    const fetch = stub(); fetch.mockResolvedValueOnce(response({ status: "acknowledged" }));
+    await expect(new QdrantClientIndex(config).upsert(spec, [point])).rejects.toBeInstanceOf(QdrantIndexError);
+  });
+  it("search verifies exact counts, filters current state, preserves cosine and stable ordering", async () => {
+    const fetch = stub(); const actual = await new QdrantClientIndex(config).search(spec, new Float32Array([1, 0, 0]), 1);
+    expect(actual).toEqual([{ chunkId: record.chunkId, score: 1 }]);
+    const count = fetch.mock.calls.filter(([url]) => String(url).endsWith("/count"));
+    expect(count).toHaveLength(2); expect(count.every(([, init]) => JSON.parse(init!.body as string).exact === true)).toBe(true);
+    const body = JSON.parse(fetch.mock.calls.at(-1)![1]!.body as string) as { filter: unknown; with_vector: boolean };
+    expect(body.with_vector).toBe(false); expect(JSON.stringify(body.filter)).toContain("test-build");
+  });
+  it("sorts all candidates by score then chunkId before limiting", async () => {
+    const fetch = stub(); const many = { ...spec, count: 3 };
+    fetch.mockImplementation(async (input) => {
+      const path = String(input);
+      if (path.endsWith("/count")) return response({ count: 3 });
+      if (path.endsWith("/query")) return response({ points: ["z", "a", "b"].map((chunkId) => ({ id: pointId(VAULT_A, chunkId),
+        score: chunkId === "b" ? 0 : 1, payload: { ...point.payload, chunkId } })) });
+      return response({ status: "green", config: { params: { vectors: { size: 3, distance: "Cosine" } }, metadata: { vaultAuditOwner: spec.owner } } });
+    });
+    expect(await new QdrantClientIndex(config).search(many, new Float32Array([1, 0, 0]), 2)).toEqual([{ chunkId: "a", score: 1 }, { chunkId: "z", score: 1 }]);
+  });
+  it("rejects a bounded window cutting a larger exact tie so SQLite can resolve it", async () => {
+    const fetch = stub();
+    fetch.mockImplementation(async (input, init) => {
+      if (String(input).endsWith("/count")) return response({ count: 300 });
+      if (String(input).endsWith("/query")) return response({ points: Array.from({ length: JSON.parse(init!.body as string).limit as number }, (_, i) => {
+        const chunkId = `id-${i}`; return { id: pointId(VAULT_A, chunkId), score: 1, payload: { ...point.payload, chunkId } };
+      }) });
+      return response({ status: "green", config: { params: { vectors: { size: 3, distance: "Cosine" } }, metadata: { vaultAuditOwner: spec.owner } } });
+    });
+    await expect(new QdrantClientIndex(config).search({ ...spec, count: 300 }, new Float32Array([1, 0, 0]), 1)).rejects.toBeInstanceOf(QdrantIndexError);
+  });
+  it.each(["missing", "empty", "partial", "stale"])("rejects %s index before querying", async (mode) => {
+    const fetch = stub();
+    if (mode === "missing") fetch.mockResolvedValueOnce(new Response(secret, { status: 404 }));
+    else {
+      const original = fetch.getMockImplementation()!;
+      let counts = 0;
+      fetch.mockImplementation((input, init) => String(input).endsWith("/count")
+        ? Promise.resolve(response({ count: mode === "stale" && ++counts === 1 ? 1 : 0 })) : original(input, init));
+    }
+    await expect(new QdrantClientIndex(config).search(spec, new Float32Array([1, 0, 0]), 1)).rejects.toThrow();
+    expect(fetch.mock.calls.some(([url]) => String(url).endsWith("/query"))).toBe(false);
+  });
+  it.each([[], [{ id: point.id, score: 1, payload: { ...point.payload, chunkId: "forged" } }],
+    [{ id: point.id, score: 1, payload: { ...point.payload, generation: 6 } }],
+    [{ id: point.id, score: 1, payload: { ...point.payload, embeddingSpaceId: "wrong" } }],
+    [{ id: point.id, score: 2, payload: point.payload }], [{ id: point.id, score: 1 }]].map((points) => ({ points })))("rejects malformed search results %j", async ({ points }) => {
+    const fetch = stub(); const original = fetch.getMockImplementation()!;
+    fetch.mockImplementation((input, init) => String(input).endsWith("/query") ? Promise.resolve(response({ points })) : original(input, init));
+    await expect(new QdrantClientIndex(config).search(spec, new Float32Array([1, 0, 0]), 1)).rejects.toBeInstanceOf(QdrantIndexError);
+  });
+  it.each([1.0000004, -1.0000004])("clamps only Float32 cosine roundoff %s", async (score) => {
+    const fetch = stub(); const original = fetch.getMockImplementation()!;
+    fetch.mockImplementation((input, init) => String(input).endsWith("/query")
+      ? Promise.resolve(response({ points: [{ id: point.id, score, payload: point.payload }] })) : original(input, init));
+    expect(await new QdrantClientIndex(config).search(spec, new Float32Array([1, 0, 0]), 1))
+      .toEqual([{ chunkId: record.chunkId, score: Math.sign(score) }]);
+  });
+  it("rejects malformed API key characters with sanitized configuration and constructor errors", () => {
+    expect(() => loadQdrantConfig({ QDRANT_API_KEY: `${secret}\ninvalid` })).toThrow("QDRANT_API_KEY must contain printable ASCII characters.");
+    expect(() => new QdrantClientIndex({ ...config, apiKey: `${secret}\ninvalid` })).toThrow("QDRANT_UNAVAILABLE");
+  });
+  it("redacts server errors and never logs secrets", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const fetch = stub(); fetch.mockResolvedValueOnce(new Response(`upstream ${secret}`, { status: 500 }));
+    await expect(new QdrantClientIndex(config).ensureCollection(spec)).rejects.toMatchObject({ message: "QDRANT_UNAVAILABLE" });
+    expect(warn).not.toHaveBeenCalled();
+  });
+  it("uses authenticated requests with redirects refused and honors HTTPS default port/prefix", async () => {
+    const fetch = stub(); await new QdrantClientIndex({ ...config, url: "https://q.example/proxy" }).ensureCollection(spec);
+    for (const [url, init] of fetch.mock.calls) {
+      expect(String(url)).toMatch(/^https:\/\/q.example\/proxy\/collections\//u);
+      expect(init?.redirect).toBe("error"); expect(new Headers(init?.headers).get("api-key")).toBe(secret);
+    }
+  });
+  it("times out real local HTTP requests with a sanitized error", async () => {
+    const server = createServer(() => {});
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const index = new QdrantClientIndex({ ...config, timeoutMs: 100, url: `http://127.0.0.1:${(server.address() as AddressInfo).port}` });
+    const start = performance.now();
+    try {
+      await expect(index.ensureCollection(spec)).rejects.toMatchObject({ message: "QDRANT_UNAVAILABLE" });
+      expect(performance.now() - start).toBeLessThan(2000);
+    } finally { index.close(); server.closeAllConnections(); await new Promise<void>((resolve) => server.close(() => resolve())); }
+  });
+  it("close refuses subsequent calls", async () => {
+    const fetch = stub(); const index = new QdrantClientIndex(config); index.close();
+    await expect(index.ensureCollection(spec)).rejects.toThrow(); expect(fetch).not.toHaveBeenCalled();
+  });
+});

--- a/companion/tests/qdrantServer.test.ts
+++ b/companion/tests/qdrantServer.test.ts
@@ -1,0 +1,62 @@
+import { Client, StreamableHTTPClientTransport } from "@modelcontextprotocol/client";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AddressInfo } from "node:net";
+import { describe, expect, it, vi } from "vitest";
+import { loadConfig } from "../src/config.js";
+import { createCompanionServer } from "../src/server.js";
+import { SqliteCompanionStorage } from "../src/storage/sqliteCompanionStorage.js";
+import { FakeQdrantIndex } from "./qdrantFixture.js";
+import { note, upsertBatch, VAULT_A } from "./fixtures.js";
+
+describe("Qdrant HTTP/MCP integration", () => {
+  it("starts offline, keeps tokens and health private, automatically repairs, then isolates a failed sync update", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "qdrant-http-"));
+    const storage = new SqliteCompanionStorage(directory); await storage.initialize();
+    await storage.applyBatch(VAULT_A, upsertBatch(1, [note("A.md", "private content", [1, 0, 0])]));
+    const config = loadConfig({ COMPANION_TOKEN: "sync-secret", MCP_TOKEN: "read-secret", MCP_ENABLED: "true",
+      MCP_VAULT_ID: VAULT_A, QDRANT_ENABLED: "true", QDRANT_API_KEY: "qdrant-private-key", DATA_DIR: directory });
+    const index = new FakeQdrantIndex(); index.fail = "all";
+    const logs: unknown[] = [];
+    const log = (message: string, context?: Record<string, unknown>): void => { logs.push({ message, context }); };
+    const provider = { embedQuery: vi.fn(async () => new Float32Array([1, 0, 0])) };
+    const server = createCompanionServer(config, storage, { debug: log, info: log, warn: log, error: log }, provider, index);
+    const client = new Client({ name: "qdrant-test", version: "1" });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const base = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+    const headers = { authorization: `Bearer ${config.token}`, "x-companion-protocol-version": "1" };
+    async function status(): Promise<{ state: string; lastSearchBackend: string }> {
+      const body = await (await fetch(`${base}/v1/status`, { headers })).json() as { qdrant: { state: string; lastSearchBackend: string } };
+      expect(JSON.stringify(body)).not.toContain(config.qdrant!.apiKey);
+      return body.qdrant;
+    }
+    try {
+      expect(await (await fetch(`${base}/health`)).json()).toEqual({ status: "ok", protocolVersion: 1 });
+      expect((await fetch(`${base}/v1/status`)).status).toBe(401);
+      expect((await fetch(`${base}/v1/status`, { headers: { ...headers, authorization: `Bearer ${config.mcp.token}` } })).status).toBe(401);
+      await client.connect(new StreamableHTTPClientTransport(new URL(`${base}/mcp`), { authProvider: { token: async (): Promise<string> => config.mcp.token } }));
+      const tools = await client.listTools();
+      expect(tools.tools.map((tool) => tool.name)).toEqual(["vault_status", "list_notes", "get_note", "get_chunks", "search_vault"]);
+      expect(JSON.stringify(tools)).not.toMatch(/qdrant|backend/iu);
+      const request = { name: "search_vault", arguments: { query: "private query", limit: 1 } };
+      expect((await client.callTool(request)).isError).not.toBe(true);
+      expect(provider.embedQuery).toHaveBeenCalledTimes(1); expect((await status()).lastSearchBackend).toBe("sqlite");
+      index.fail = null;
+      await vi.waitFor(async () => { expect((await status()).state).toBe("READY"); }, { timeout: 5000 });
+      expect((await client.callTool(request)).isError).not.toBe(true); expect((await status()).lastSearchBackend).toBe("qdrant");
+      expect(provider.embedQuery).toHaveBeenCalledTimes(2);
+      index.fail = "upsert";
+      const sync = await fetch(`${base}/v1/vaults/${VAULT_A}/sync/batch`, { method: "POST",
+        headers: { ...headers, "content-type": "application/json" }, body: JSON.stringify(upsertBatch(2, [note("B.md", "b", [1, 0, 0])])) });
+      expect(sync.status).toBe(200); expect(await sync.json()).toMatchObject({ applied: true, generation: 2 });
+      await vi.waitFor(async () => { expect((await status()).state).toBe("ERROR"); });
+      expect((await client.callTool(request)).isError).not.toBe(true); expect((await status()).lastSearchBackend).toBe("sqlite");
+      expect(provider.embedQuery).toHaveBeenCalledTimes(3);
+      expect(JSON.stringify(logs)).not.toMatch(/qdrant-private-key|sync-secret|read-secret|private content|private query|upstream/u);
+    } finally {
+      await client.close(); await new Promise<void>((resolve) => server.close(() => resolve()));
+      await storage.close(); await rm(directory, { recursive: true, force: true });
+    }
+  });
+});

--- a/companion/tests/server.test.ts
+++ b/companion/tests/server.test.ts
@@ -88,7 +88,7 @@ describe("Companion HTTP API", () => {
   it("accepts valid authentication", async () => {
     const response = await fetch(`${baseUrl}/v1/status`, { headers: headers() });
     expect(response.status).toBe(200);
-    expect(await response.json()).toEqual({ status: "ok", protocolVersion: 1, vaultCount: 0 });
+    expect(await response.json()).toEqual({ status: "ok", protocolVersion: 1, vaultCount: 0, qdrant: { enabled: false, state: "DISABLED" } });
   });
 
   it("rejects an incompatible protocol explicitly", async () => {


### PR DESCRIPTION
## Change

Add optional Qdrant semantic retrieval to the standalone Companion. SQLite remains the authoritative persistent mirror. With Qdrant disabled, unavailable, rebuilding, stale, incompatible, or returning invalid results, `search_vault({ query, limit? })` uses the permanent SQLite backend. The five Stage 9 MCP tools and their inputs/outputs remain compatible; no backend argument, plugin settings, Vault writes, or Stage 11 work was added.

- Baseline: `73cf2726b4af63e20a8b631fedd56c7cbb7e8c50`.
- Final HEAD: `c154d5c52c04c31b5ad93ea7a848304a0ddac099`.
- Branch: `feature/stage-10-qdrant-adapter`, targeting `main`.
- Fresh main confirmed Stage 9 merged, its temporary verification report removed, and a clean working tree.
- Three focused commits: implementation/tests, mutation audit, durable operator documentation.
- Official client: [`@qdrant/js-client-rest`](https://github.com/qdrant/qdrant-js), pinned to **1.19.0**, entirely inside `companion/`.
- No plugin changes, version bumps, merges, releases, or committed verification artifacts.

## Authority and retrieval

`SemanticSearchService` creates and validates one normalized query vector, selects `SQLiteVectorBackend` or `QdrantVectorBackend`, and hydrates winning IDs through SQLite. The narrow `QdrantVectorIndex` interface isolates the official SDK and enables deterministic offline failure tests. `SqliteSemanticSearch` remains an independently testable SQLite-only entry point.

SQLite alone owns Markdown, note/chunk identity, text, metadata, vectors, descriptor, generation and sync state. Post-commit notifications enqueue derived work only after SQLite COMMIT succeeds. Observer failures cannot change a successful sync response. Tests cover actual COMMIT failure/rollback, a separate SQLite reader observing committed state before notification, and secondary-index failure after successful sync.

Readiness requires `READY` and an exact match of Vault, generation, internal persisted commit revision, chunk count and complete semantic descriptor. The revision is necessary because Stage 8 permits multiple committed batches with the same generation. Schema migration adds it without modifying existing note content or vectors. Every process restart distrusts old derived readiness.

Collections are `<prefix>_<128-bit SHA-256 vault hash>_<128-bit SHA-256 space hash>`, with a full SHA-256 ownership marker in collection metadata. Unknown or incompatible collections are not cleared. IDs are deterministic UUIDv8 values derived from SHA-256 of JSON `[vaultId, chunkId]`. Point payloads contain only chunk/Vault/space identity, generation, revision, a build stamp and a hashed note path for deletion. Full Markdown, chunk text and source metadata are not stored in Qdrant.

Descriptor replacement immediately invalidates the old collection for search and builds a new collection using the new SQLite vectors. No cross-space mixing, vector conversion, or note embedding occurs. Old owned collections are retained conservatively.

## Rebuild, incremental updates and fallback

Startup initializes SQLite and starts HTTP/MCP independently of Qdrant. A single background worker reads SQLite via keyset pages and upserts batches of at most 128 vectors. It does not hold SQLite cursors across network waits or materialize the whole Vault. Completed writes, collection ownership/dimensions/Cosine distance, exact total/current point counts, and a final unchanged SQLite snapshot check are required before READY publication. A unique build stamp detects old restored snapshots and late writes.

For one pending compatible commit, incremental reconciliation deletes affected hashed note identities, uploads their current SQLite vectors, and stamps retained points for the new generation/revision/build. UPSERT replaces old vectors; DELETE removes points; RENAME handles the existing Stage 8 delete-old/destination-and-insert-new representation. Several pending commits coalesce into a complete rebuild. Failed/partial changes remain untrusted and recover from SQLite without Obsidian resync.

Qdrant search checks collection compatibility and exact total/current counts before retrieval. Candidate IDs/scores are validated, sorted score DESC then chunkId ASC, and hydrated from current SQLite. Missing authoritative winners, partial/malformed responses, timeouts, missing collections and races discard the entire derived result. Fallback reuses the same normalized vector. A new descriptor rejects an old-space query vector. Cosine scores retain their public meaning, allowing only Float32 roundoff clamping within 1e-6. A bounded candidate window cutting a tie falls back to SQLite.

One search uses at most **one query embedding**, including Qdrant failure plus SQLite fallback; empty mirrors use zero. Rebuild/incremental work and the other four MCP tools use **zero embeddings**. Stored-note/chunk re-embedding count is **zero**.

## Security and operations

Qdrant defaults disabled. The API key is server-side only and is excluded from SQLite, MCP, health, status, logs and error text. Configuration rejects credentials/query/fragment in URLs and malformed key characters without echoing them. Remote HTTP requires explicit opt-in, including private IPs; production documentation prefers HTTPS/private networking. Every SDK request refuses redirects, preventing key forwarding. SDK errors are reduced to fixed codes.

Requests have configurable timeouts, no per-request retries, and four SDK connections maximum. One worker and one coalesced pending change bound reconciliation concurrency/state. Failed passes back off 2–30 seconds; healthy maintenance runs every 30 seconds. Public `/health` remains unchanged. Authenticated `GET /v1/status` adds safe readiness, collection, generation/revision, error, successful-sync time and most-recent retrieval backend diagnostics. MCP `vault_status` is unchanged.

Local example, alongside normal Companion/MCP credentials:

```dotenv
MCP_VAULT_ID=11111111-1111-4111-8111-111111111111
QDRANT_ENABLED=true
QDRANT_URL=http://127.0.0.1:6333
QDRANT_API_KEY=
QDRANT_TIMEOUT_MS=5000
QDRANT_COLLECTION_PREFIX=vault_audit
QDRANT_ALLOW_INSECURE_REMOTE_HTTP=false
```

VPS/private-network HTTPS example:

```dotenv
MCP_VAULT_ID=11111111-1111-4111-8111-111111111111
QDRANT_ENABLED=true
QDRANT_URL=https://qdrant.internal.example
QDRANT_API_KEY=replace-with-a-private-server-side-key
QDRANT_TIMEOUT_MS=5000
QDRANT_COLLECTION_PREFIX=vault_audit_vps
QDRANT_ALLOW_INSECURE_REMOTE_HTTP=false
```

A deliberately isolated plaintext private endpoint requires `QDRANT_ALLOW_INSECURE_REMOTE_HTTP=true`. The same Companion build supports local/VPS deployments; Docker is optional. Durable instructions are in `companion/README.md`.

## Validation

| Check | Result |
| --- | --- |
| Baseline plugin | 730 tests / 23 files passed; lint, TypeScript, build and diff check passed |
| Final plugin | 730 tests / 23 files passed; zero source changes |
| Baseline Companion | 92 tests / 9 files passed after npm ci; lint, production/test typechecks and build passed |
| Final Companion | **179 tests / 12 files passed**; lint, production/test typechecks and build passed |
| Lint warnings | Same two existing plugin warnings: api.ts:413 fetch/requestUrl; settings.ts:108 getSettingDefinitions. Companion has zero warnings |
| Isolated sparse checkout | Fresh checkout at final HEAD containing only companion/, no root package/source; npm ci, lint, both typechecks, 179 tests and build passed with QDRANT_ENABLED=false and no Qdrant server |
| Stage 9 MCP smoke | All five tools passed with modern 2026-07-28 and legacy 2025-11-25, before/after Companion restart; 4 query HTTP calls, zero note embeddings |
| Mutation audit | **21/21 killed**: 10 retained Stage 9 mutations plus all 11 requested Stage 10 A–K mutations; every restored test passed; disposable copies only |
| Search parity | Deterministic IDs, scores and final ordering match SQLite; non-axis vectors checked within 1e-6 Float32 tolerance; exact live fixture parity |
| Live Qdrant | Official native Qdrant **1.19.1** in /tmp, authenticated with temporary credentials; no Docker required |
| Real Codex | All five read-only MCP calls succeeded; search used Qdrant; one query embedding |
| Deliberate outage | Companion/MCP started with Qdrant absent; stopping Qdrant after READY preserved the same search through SQLite with exactly one embedding |
| Recovery/restarts | Qdrant restart automatically repaired READY without resync; incremental vector modification, DELETE, RENAME and Companion restart passed |
| Live embedding cost | **8 searches, 8 query embedding HTTP requests, zero note/chunk re-embedding** |
| Benchmark | Not run; no performance claims |
| Repository hygiene | Clean working tree; no verification, smoke, audit, benchmark, generated data or report artifacts committed |

The live smoke used a disposable synthetic SQLite mirror and a deterministic local embedding HTTP fixture, plus a real Qdrant server and real Codex client. It did not make a live OpenRouter/commercial embedding request or access private Vault content. Existing OpenRouter canonicalization tests remain green.

## Changed files

All 24 changed files are inside Companion:

```text
companion/README.md
companion/package-lock.json
companion/package.json
companion/scripts/mutation-audit.mjs
companion/src/config.ts
companion/src/mcp/mcpServer.ts
companion/src/mcp/semanticSearch.ts
companion/src/mcp/service.ts
companion/src/search/qdrantBackend.ts
companion/src/search/qdrantIndex.ts
companion/src/search/sqliteVectorBackend.ts
companion/src/search/vectorBackend.ts
companion/src/search/vectorMath.ts
companion/src/server.ts
companion/src/storage/companionStorage.ts
companion/src/storage/mcpReadStorage.ts
companion/src/storage/migrations.ts
companion/src/storage/sqliteCompanionStorage.ts
companion/tests/mcpSemanticSearch.test.ts
companion/tests/qdrantBackend.test.ts
companion/tests/qdrantFixture.ts
companion/tests/qdrantIndex.test.ts
companion/tests/qdrantServer.test.ts
companion/tests/server.test.ts
```

## Known limitations

- Target server is Qdrant 1.19.x with collection metadata support; incompatible servers fall back.
- One Companion writer must own each prefix/Vault/space collection. Ownership metadata is not a distributed lock; manually modifying indexed payloads/vectors is unsupported.
- Companion restarts rebuild; old-space collections are retained for conservative manual cleanup.
- ANN results can differ on larger data; candidate retrieval is bounded and cut ties fall back to SQLite.
- Exact count/metadata checks add round trips; a failed search can incur several per-request timeouts before SQLite fallback. No benchmark was run.
- A single pending commit updates affected vectors incrementally but stamps retained point metadata across the collection; coalesced commits rebuild.
- No Stage 11 writes, approval queue, agent system, deployment provisioning, or plugin Qdrant configuration was introduced.

Ready for review. Stop before merge; no release or version bump.


PR URL: https://github.com/zinverno/obsidian-ai-hub/pull/18
